### PR TITLE
Update MAINTAINERS.md with corrected affiliation

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,4 +8,4 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | --------------------- | ------------------------------------------------------------- | ----------- |
 | Mingshi Liu           | [kaituo](https://github.com/mingshl)                          | Amazon      |
 | Jiaping Zeng          | [jiapingzeng](https://github.com/jiapingzeng)                 | Amazon      |
-| Daniel Wrigley        | [wrigleyDan](https://github.com/wrigleyDan)                   | Amazon      |
+| Daniel Wrigley        | [wrigleyDan](https://github.com/wrigleyDan)                   | OpenSource Connections      |


### PR DESCRIPTION
### Description
I have the wrong affiliation in the list of maintainers. This PR changes my affiliation from Amazon to OpenSource Connections.

### Issues Resolved
n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
