### PR TITLE
Fix of wrong module paths for experiment tool

### DIFF
--- a/src/agents/art/specialized_agents.py
+++ b/src/agents/art/specialized_agents.py
@@ -223,7 +223,7 @@ async def hypothesis_agent(query: str) -> str:
     try:
         # Import experimentation tools. This agent is meant to do only sanity checks,
         # so we don't need all experiment tools.
-        from tools.art.experiment_tools import (
+        from src.tools.art.experiment_tools import (
             aggregate_experiment_results,
         )
 
@@ -279,7 +279,7 @@ async def evaluation_agent(query: str) -> str:
 
     try:
         # Import evaluation-specific tools
-        from tools.art.experiment_tools import (
+        from src.tools.art.experiment_tools import (
             aggregate_experiment_results,
         )
 

--- a/tests/unit/test_experiment_tools.py
+++ b/tests/unit/test_experiment_tools.py
@@ -12,7 +12,7 @@ from unittest.mock import patch
 
 import pytest
 
-from tools.art.experiment_tools import (
+from src.tools.art.experiment_tools import (
     aggregate_experiment_results,
 )
 

--- a/tests/unit/test_experiment_tools_errors.py
+++ b/tests/unit/test_experiment_tools_errors.py
@@ -12,7 +12,7 @@ from unittest.mock import patch
 
 import pytest
 
-from tools.art.experiment_tools import (
+from src.tools.art.experiment_tools import (
     aggregate_experiment_results,
 )
 


### PR DESCRIPTION
### Description
Fix of import paths, which fixes utilization of experiment tool, avoiding import errors 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Andreas Wagenmann <awagen@posteo.net>
