### PR TITLE
Add search workspace to list of page contexts that use ART

### DIFF
--- a/src/server/ag_ui_app.py
+++ b/src/server/ag_ui_app.py
@@ -317,7 +317,7 @@ def create_app(config_override: ServerConfig | None = None) -> FastAPI:
             description="Search Relevance Tuning agent (ART) — hypothesis generation, "
             "evaluation, and UBI analysis.",
             page_contexts=["search_overview", "search-relevance", "searchRelevance"],
-            is_fallback=False,
+            is_default=False,
         ))
 
         # Register default agent (handles all unmatched page contexts)


### PR DESCRIPTION
### Description
Adds ART to the Search Workspace using page_context.   

There is a longer term effort to rework the search workspace to make it more useful and less a set of links to documentation ;-).   This fits into that effort.

Tested via ` ./scripts/test_run.sh "How do I use the hypothesis agent?" localhost:8001 search_overview`

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 
n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
