### PR TITLE
Feature/fix engagement calculation inaccuracies

### DIFF
--- a/src/agents/art/specialized_agents.py
+++ b/src/agents/art/specialized_agents.py
@@ -25,6 +25,8 @@ sys.path.insert(0, _src_dir)
 from tools.art.experiment_tools import (
     aggregate_experiment_results,
 )
+from tools.art.analysis_tools import get_query_ctr, get_document_ctr, get_query_performance_metrics, \
+    get_top_queries_by_engagement, get_top_documents_by_engagement
 
 logger = get_logger(__name__)
 
@@ -193,6 +195,8 @@ Relevant indexes for your job are indexes holding UBI data. If not specified oth
 for client-side tracked events and ubi_queries for server-side tracked events.
 Be concise, data-driven, specific with numbers, and focus on actual user behavior rather than theoretical analysis.
 Always include concrete metrics (CTR percentages, click counts, search volumes) to support your insights.
+If you find specific functions to call for the values you need
+for analysis, use them, otherwise refer to the MCP tools.
 """
 
 
@@ -341,6 +345,11 @@ async def user_behavior_analysis_agent(query: str) -> str:
         )
 
         ubi_tools = [
+            get_query_ctr,
+            get_document_ctr,
+            get_query_performance_metrics,
+            get_top_queries_by_engagement,
+            get_top_documents_by_engagement,
             # OpenSearch MCP tools
             *_opensearch_tools,
         ]

--- a/src/tools/art/analysis_tools.py
+++ b/src/tools/art/analysis_tools.py
@@ -1,0 +1,573 @@
+import json
+import os
+from datetime import UTC, datetime, timedelta
+
+import dotenv
+
+from tools.art.opensearch_client import OpenSearchClientManager, get_client_manager
+from utils.logging_helpers import get_logger
+from utils.monitored_tool import monitored_tool
+from utils.tool_utils import log_tool_error
+
+logger = get_logger(__name__)
+
+dotenv.load_dotenv(dotenv.find_dotenv(".env"))
+
+
+@monitored_tool(
+    name="GetQueryCTRTool",
+    description="Calculate click-through rate (CTR) for a specific search query based on user behavior events",
+)
+async def get_query_ctr(
+    query_text: str,
+    time_range_days: int = 30,
+    ubi_index: str = "ubi_events",
+) -> str:
+    """
+    Calculate click-through rate for a specific query.
+
+    Args:
+        query_text: The search query text to analyze
+        time_range_days: Number of days to look back (default: 30)
+        ubi_index: Name of the UBI events index (default: "ubi_events")
+
+    Returns:
+        str: JSON string with query CTR metrics including total searches,
+             searches with clicks, CTR percentage, and average clicks per search
+    """
+    try:
+        client_manager: OpenSearchClientManager = get_client_manager(
+            opensearch_url=os.environ["OPENSEARCH_URL"],
+            username=os.environ.get("OPENSEARCH_USERNAME", "admin"),
+            password=os.environ.get("OPENSEARCH_PASSWORD", "")
+        )
+        client = client_manager.get_client()
+
+        # Calculate time range (format without microseconds for OpenSearch)
+        end_time = datetime.now(UTC)
+        start_time = end_time - timedelta(days=time_range_days)
+
+        # Format timestamps without microseconds
+        end_time_str = end_time.strftime("%Y-%m-%dT%H:%M:%SZ")
+        start_time_str = start_time.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        # Query to get search and click counts for the query
+        query_body = {
+            "size": 0,
+            "query": {
+                "bool": {
+                    "must": [
+                        {"term": {"user_query": query_text}},
+                        {
+                            "range": {
+                                "timestamp": {
+                                    "gte": start_time_str,
+                                    "lte": end_time_str,
+                                },
+                            },
+                        },
+                    ],
+                },
+            },
+            "aggs": {
+                "total_searches": {
+                    "cardinality": {
+                        "field": "query_id",
+                    },
+                },
+                "searches_with_clicks": {
+                    "filter": {
+                        "term": {
+                            "action_name": "click",
+                        },
+                    },
+                    "aggs": {
+                        "unique_queries": {
+                            "cardinality": {
+                                "field": "query_id",
+                            },
+                        },
+                    },
+                },
+            },
+        }
+
+        response = client.search(
+            index=ubi_index,
+            body=query_body,
+        )
+
+        total_searches = response["aggregations"]["total_searches"]["value"]
+        searches_with_clicks = response["aggregations"]["searches_with_clicks"][
+            "unique_queries"
+        ]["value"]
+        total_clicks = response["aggregations"]["searches_with_clicks"]["doc_count"]
+
+        ctr = (searches_with_clicks / total_searches * 100) if total_searches > 0 else 0
+        avg_clicks = (total_clicks / total_searches) if total_searches > 0 else 0
+        zero_click_rate = (
+            ((total_searches - searches_with_clicks) / total_searches * 100)
+            if total_searches > 0
+            else 0
+        )
+
+        result = {
+            "query_text": query_text,
+            "time_range_days": time_range_days,
+            "total_searches": total_searches,
+            "searches_with_clicks": searches_with_clicks,
+            "total_clicks": total_clicks,
+            "ctr_percentage": round(ctr, 2),
+            "average_clicks_per_search": round(avg_clicks, 2),
+            "zero_click_rate_percentage": round(zero_click_rate, 2),
+        }
+
+        return json.dumps(result, indent=2)
+
+    except Exception as e:
+        return log_tool_error(logger, f"Error calculating query CTR: {str(e)}")
+
+
+@monitored_tool(
+    name="GetDocumentCTRTool",
+    description="Calculate click-through rate (CTR) for a specific document based on user behavior events",
+)
+async def get_document_ctr(
+    doc_id: str, time_range_days: int = 30, ubi_index: str = "ubi_events"
+) -> str:
+    """
+    Calculate click-through rate for a specific document.
+
+    Args:
+        doc_id: The document ID to analyze
+        time_range_days: Number of days to look back (default: 30)
+        ubi_index: Name of the UBI events index (default: "ubi_events")
+
+    Returns:
+        str: JSON string with document CTR metrics including total impressions,
+             total clicks, CTR percentage, and average position when clicked
+    """
+    try:
+        client_manager: OpenSearchClientManager = get_client_manager(
+            opensearch_url=os.environ["OPENSEARCH_URL"],
+            username=os.environ.get("OPENSEARCH_USERNAME", "admin"),
+            password=os.environ.get("OPENSEARCH_PASSWORD", "")
+        )
+        client = client_manager.get_client()
+
+        # Calculate time range (format without microseconds for OpenSearch)
+        end_time = datetime.now(UTC)
+        start_time = end_time - timedelta(days=time_range_days)
+
+        # Format timestamps without microseconds
+        end_time_str = end_time.strftime("%Y-%m-%dT%H:%M:%SZ")
+        start_time_str = start_time.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        # Query to get impression and click counts for the document
+        query_body = {
+            "size": 0,
+            "query": {
+                "bool": {
+                    "must": [
+                        {"term": {"event_attributes.object.object_id": doc_id}},
+                        {
+                            "range": {
+                                "timestamp": {
+                                    "gte": start_time_str,
+                                    "lte": end_time_str,
+                                },
+                            },
+                        },
+                    ],
+                },
+            },
+            "aggs": {
+                "total_impressions": {
+                    "filter": {
+                        "term": {
+                            "action_name": "impression",
+                        },
+                    },
+                },
+                "clicks": {
+                    "filter": {
+                        "term": {
+                            "action_name": "click",
+                        },
+                    },
+                    "aggs": {
+                        "avg_position": {
+                            "avg": {
+                                "field": "event_attributes.position.ordinal",
+                            },
+                        },
+                    },
+                },
+            },
+        }
+
+        response = client.search(
+            index=ubi_index,
+            body=query_body,
+        )
+
+        total_impressions = response["aggregations"]["total_impressions"]["doc_count"]
+        total_clicks = response["aggregations"]["clicks"]["doc_count"]
+        avg_position = response["aggregations"]["clicks"]["avg_position"]["value"]
+
+        ctr = (total_clicks / total_impressions * 100) if total_impressions > 0 else 0
+
+        result = {
+            "document_id": doc_id,
+            "time_range_days": time_range_days,
+            "total_impressions": total_impressions,
+            "total_clicks": total_clicks,
+            "ctr_percentage": round(ctr, 2),
+            "average_position_when_clicked": round(avg_position, 2)
+            if avg_position
+            else None,
+        }
+
+        return json.dumps(result, indent=2)
+
+    except Exception as e:
+        return log_tool_error(logger, f"Error calculating document CTR: {str(e)}")
+
+
+@monitored_tool(
+    name="GetQueryPerformanceMetricsTool",
+    description="Get comprehensive performance metrics for queries. Can analyze a specific query or return top N queries by volume with their metrics.",
+)
+async def get_query_performance_metrics(
+    query_text: str | None = None,
+    top_n: int = 20,
+    time_range_days: int = 30,
+    ubi_index: str = "ubi_events",
+) -> str:
+    """
+    Get comprehensive performance metrics for queries.
+    If query_text provided: detailed metrics for that query
+    If query_text is None: top N queries by volume with their metrics
+
+    Args:
+        query_text: Specific query to analyze (optional)
+        top_n: Number of top queries to return if query_text not provided (default: 20)
+        time_range_days: Number of days to look back (default: 30)
+        ubi_index: Name of the UBI events index (default: "ubi_events")
+
+    Returns:
+        str: JSON string with performance metrics for query/queries
+    """
+    try:
+        client_manager: OpenSearchClientManager = get_client_manager(
+            opensearch_url=os.environ["OPENSEARCH_URL"],
+            username=os.environ.get("OPENSEARCH_USERNAME", "admin"),
+            password=os.environ.get("OPENSEARCH_PASSWORD", "")
+        )
+        client = client_manager.get_client()
+
+        # Calculate time range (format without microseconds for OpenSearch)
+        end_time = datetime.now(UTC)
+        start_time = end_time - timedelta(days=time_range_days)
+
+        # Format timestamps without microseconds
+        end_time_str = end_time.strftime("%Y-%m-%dT%H:%M:%SZ")
+        start_time_str = start_time.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        # If specific query provided, use GetQueryCTRTool
+        if query_text:
+            return await get_query_ctr(query_text, time_range_days, ubi_index)
+
+        # Otherwise, get top queries with metrics
+        query_body = {
+            "size": 0,
+            "query": {
+                "range": {
+                    "timestamp": {
+                        "gte": start_time_str,
+                        "lte": end_time_str,
+                    },
+                },
+            },
+            "aggs": {
+                "top_queries": {
+                    "terms": {
+                        "field": "user_query",
+                        "size": top_n,
+                        "order": {
+                            "_count": "desc",
+                        },
+                    },
+                    "aggs": {
+                        "unique_searches": {
+                            "cardinality": {
+                                "field": "query_id",
+                            },
+                        },
+                        "click_events": {
+                            "filter": {
+                                "term": {
+                                    "action_name": "click",
+                                },
+                            },
+                            "aggs": {
+                                "unique_queries_with_clicks": {
+                                    "cardinality": {
+                                        "field": "query_id",
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        }
+
+        response = client.search(
+            index=ubi_index,
+            body=query_body,
+        )
+
+        queries = []
+        for bucket in response["aggregations"]["top_queries"]["buckets"]:
+            query = bucket["key"]
+            total_searches = bucket["unique_searches"]["value"]
+            searches_with_clicks = bucket["click_events"]["unique_queries_with_clicks"][
+                "value"
+            ]
+            total_clicks = bucket["click_events"]["doc_count"]
+
+            ctr = (
+                (searches_with_clicks / total_searches * 100)
+                if total_searches > 0
+                else 0
+            )
+            avg_clicks = (total_clicks / total_searches) if total_searches > 0 else 0
+            zero_click_rate = (
+                ((total_searches - searches_with_clicks) / total_searches * 100)
+                if total_searches > 0
+                else 0
+            )
+
+            queries.append(
+                {
+                    "query_text": query,
+                    "search_volume": total_searches,
+                    "searches_with_clicks": searches_with_clicks,
+                    "total_clicks": total_clicks,
+                    "ctr_percentage": round(ctr, 2),
+                    "average_clicks_per_search": round(avg_clicks, 2),
+                    "zero_click_rate_percentage": round(zero_click_rate, 2),
+                }
+            )
+
+        result = {
+            "time_range_days": time_range_days,
+            "total_queries_analyzed": len(queries),
+            "queries": queries,
+        }
+
+        return json.dumps(result, indent=2)
+
+    except Exception as e:
+        return log_tool_error(
+            logger, f"Error getting query performance metrics: {str(e)}"
+        )
+
+
+@monitored_tool(
+    name="GetTopQueriesByEngagementTool",
+    description="Get queries with highest click-through rates (best engagement)",
+)
+async def get_top_queries_by_engagement(
+    top_n: int = 20,
+    min_search_volume: int = 5,
+    time_range_days: int = 30,
+    ubi_index: str = "ubi_events",
+) -> str:
+    """
+    Get queries with highest CTR (best engagement).
+    Filters out low-volume queries to ensure statistical significance.
+
+    Args:
+        top_n: Number of top queries to return (default: 20)
+        min_search_volume: Minimum number of searches required (default: 5)
+        time_range_days: Number of days to look back (default: 30)
+        ubi_index: Name of the UBI events index (default: "ubi_events")
+
+    Returns:
+        str: JSON string with top queries by CTR
+    """
+    try:
+        # Get all query metrics
+        metrics_json = await get_query_performance_metrics(
+            query_text=None,
+            top_n=100,  # Get more to filter by volume
+            time_range_days=time_range_days,
+            ubi_index=ubi_index,
+        )
+
+        metrics = json.loads(metrics_json)
+        if "error" in metrics:
+            return metrics_json
+
+        # Filter by minimum volume and sort by CTR
+        filtered_queries = [
+            q for q in metrics["queries"] if q["search_volume"] >= min_search_volume
+        ]
+
+        sorted_queries = sorted(
+            filtered_queries, key=lambda x: x["ctr_percentage"], reverse=True
+        )[:top_n]
+
+        result = {
+            "time_range_days": time_range_days,
+            "min_search_volume": min_search_volume,
+            "total_queries_analyzed": len(sorted_queries),
+            "queries": sorted_queries,
+        }
+
+        return json.dumps(result, indent=2)
+
+    except Exception as e:
+        return log_tool_error(
+            logger, f"Error getting top queries by engagement: {str(e)}"
+        )
+
+
+@monitored_tool(
+    name="GetTopDocumentsByEngagementTool",
+    description="Get documents with highest click-through rates (best engagement)",
+)
+async def get_top_documents_by_engagement(
+    top_n: int = 20,
+    min_impressions: int = 5,
+    time_range_days: int = 30,
+    ubi_index: str = "ubi_events",
+) -> str:
+    """
+    Get documents with highest CTR (best engagement).
+    Filters out low-impression documents to ensure statistical significance.
+
+    Args:
+        top_n: Number of top documents to return (default: 20)
+        min_impressions: Minimum number of impressions required (default: 5)
+        time_range_days: Number of days to look back (default: 30)
+        ubi_index: Name of the UBI events index (default: "ubi_events")
+
+    Returns:
+        str: JSON string with top documents by CTR
+    """
+    try:
+        client_manager: OpenSearchClientManager = get_client_manager(
+            opensearch_url=os.environ["OPENSEARCH_URL"],
+            username=os.environ.get("OPENSEARCH_USERNAME", "admin"),
+            password=os.environ.get("OPENSEARCH_PASSWORD", "")
+        )
+        client = client_manager.get_client()
+
+        # Calculate time range (format without microseconds for OpenSearch)
+        end_time = datetime.now(UTC)
+        start_time = end_time - timedelta(days=time_range_days)
+
+        # Format timestamps without microseconds
+        end_time_str = end_time.strftime("%Y-%m-%dT%H:%M:%SZ")
+        start_time_str = start_time.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        # Get top documents by impressions first
+        query_body = {
+            "size": 0,
+            "query": {
+                "range": {
+                    "timestamp": {
+                        "gte": start_time_str,
+                        "lte": end_time_str,
+                    },
+                },
+            },
+            "aggs": {
+                "top_documents": {
+                    "terms": {
+                        "field": "event_attributes.object.object_id",
+                        "size": 100,  # Get more to filter
+                        "order": {
+                            "_count": "desc",
+                        },
+                    },
+                    "aggs": {
+                        "impressions": {
+                            "filter": {
+                                "term": {
+                                    "action_name": "impression",
+                                },
+                            },
+                        },
+                        "clicks": {
+                            "filter": {
+                                "term": {
+                                    "action_name": "click",
+                                },
+                            },
+                            "aggs": {
+                                "avg_position": {
+                                    "avg": {
+                                        "field": "event_attributes.position.ordinal",
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        }
+
+        response = client.search(
+            index=ubi_index,
+            body=query_body,
+        )
+
+        documents = []
+        for bucket in response["aggregations"]["top_documents"]["buckets"]:
+            doc_id = bucket["key"]
+            total_impressions = bucket["impressions"]["doc_count"]
+            total_clicks = bucket["clicks"]["doc_count"]
+            avg_position = bucket["clicks"]["avg_position"]["value"]
+
+            # Filter by minimum impressions
+            if total_impressions < min_impressions:
+                continue
+
+            ctr = (
+                (total_clicks / total_impressions * 100) if total_impressions > 0 else 0
+            )
+
+            documents.append(
+                {
+                    "document_id": doc_id,
+                    "total_impressions": total_impressions,
+                    "total_clicks": total_clicks,
+                    "ctr_percentage": round(ctr, 2),
+                    "average_position_when_clicked": round(avg_position, 2)
+                    if avg_position
+                    else None,
+                }
+            )
+
+        # Sort by CTR and take top N
+        sorted_documents = sorted(
+            documents, key=lambda x: x["ctr_percentage"], reverse=True
+        )[:top_n]
+
+        result = {
+            "time_range_days": time_range_days,
+            "min_impressions": min_impressions,
+            "total_documents_analyzed": len(sorted_documents),
+            "documents": sorted_documents,
+        }
+
+        return json.dumps(result, indent=2)
+
+    except Exception as e:
+        return log_tool_error(
+            logger, f"Error getting top documents by engagement: {str(e)}"
+        )

--- a/src/tools/art/opensearch_client.py
+++ b/src/tools/art/opensearch_client.py
@@ -1,0 +1,293 @@
+"""
+OpenSearch Client Connection Utility
+Provides shared access to OpenSearch Python client with search_relevance plugin.
+
+NOTE: utilized here solely for direct requests to OS for the sake of test generation
+from existing index data.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from opensearchpy import OpenSearch
+from utils.logging_helpers import get_logger, log_info_event
+
+logger = get_logger(__name__)
+
+
+class SearchRelevanceClient:
+    """
+    Client for OpenSearch Search Relevance plugin API.
+    Provides methods to interact with search relevance endpoints.
+    """
+
+    def __init__(self, client: OpenSearch) -> None:
+        """
+        Initialize the search relevance client.
+
+        Args:
+            client: The main OpenSearch client instance
+        """
+        self._client = client
+
+    def get_search_configurations(
+        self,
+        search_configuration_id: str | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Get search configurations."""
+        if search_configuration_id:
+            path = f"/_plugins/_search_relevance/search_configurations/{search_configuration_id}"
+        else:
+            path = "/_plugins/_search_relevance/search_configurations"
+        return self._client.transport.perform_request("GET", path, params=kwargs)
+
+    def put_search_configurations(self, body: Any | None = None, **kwargs: Any) -> Any:
+        """Create or update a search configuration."""
+        path = "/_plugins/_search_relevance/search_configurations"
+        return self._client.transport.perform_request(
+            "PUT", path, body=body, params=kwargs
+        )
+
+    def delete_search_configurations(
+        self, search_configuration_id: str, **kwargs: Any
+    ) -> Any:
+        """Delete a search configuration."""
+        path = f"/_plugins/_search_relevance/search_configurations/{search_configuration_id}"
+        return self._client.transport.perform_request("DELETE", path, params=kwargs)
+
+    def get_judgments(self, judgment_id: str | None = None, **kwargs: Any) -> Any:
+        """Get judgments."""
+        if judgment_id:
+            path = f"/_plugins/_search_relevance/judgments/{judgment_id}"
+        else:
+            path = "/_plugins/_search_relevance/judgments"
+        return self._client.transport.perform_request("GET", path, params=kwargs)
+
+    def put_judgments(self, body: Any | None = None, **kwargs: Any) -> Any:
+        """Create or update a judgment."""
+        path = "/_plugins/_search_relevance/judgments"
+        return self._client.transport.perform_request(
+            "PUT", path, body=body, params=kwargs
+        )
+
+    def delete_judgments(self, judgment_id: str, **kwargs: Any) -> Any:
+        """Delete a judgment."""
+        path = f"/_plugins/_search_relevance/judgments/{judgment_id}"
+        return self._client.transport.perform_request("DELETE", path, params=kwargs)
+
+    def get_query_sets(self, query_set_id: str | None = None, **kwargs: Any) -> Any:
+        """Get query sets."""
+        if query_set_id:
+            path = f"/_plugins/_search_relevance/query_sets/{query_set_id}"
+        else:
+            path = "/_plugins/_search_relevance/query_sets"
+        return self._client.transport.perform_request("GET", path, params=kwargs)
+
+    def put_query_sets(self, body: Any | None = None, **kwargs: Any) -> Any:
+        """Create or update a query set."""
+        path = "/_plugins/_search_relevance/query_sets"
+        return self._client.transport.perform_request(
+            "PUT", path, body=body, params=kwargs
+        )
+
+    def post_query_sets(self, body: Any | None = None, **kwargs: Any) -> Any:
+        """Create a query set by sampling from UBI data."""
+        path = "/_plugins/_search_relevance/query_sets"
+        return self._client.transport.perform_request(
+            "POST", path, body=body, params=kwargs
+        )
+
+    def delete_query_sets(self, query_set_id: str, **kwargs: Any) -> Any:
+        """Delete a query set."""
+        path = f"/_plugins/_search_relevance/query_sets/{query_set_id}"
+        return self._client.transport.perform_request("DELETE", path, params=kwargs)
+
+    def get_experiments(self, experiment_id: str | None = None, **kwargs: Any) -> Any:
+        """Get experiments."""
+        if experiment_id:
+            path = f"/_plugins/_search_relevance/experiments/{experiment_id}"
+        else:
+            path = "/_plugins/_search_relevance/experiments"
+        return self._client.transport.perform_request("GET", path, params=kwargs)
+
+    def put_experiments(self, body: Any | None = None, **kwargs: Any) -> Any:
+        """Create or update an experiment."""
+        path = "/_plugins/_search_relevance/experiments"
+        return self._client.transport.perform_request(
+            "PUT", path, body=body, params=kwargs
+        )
+
+    def delete_experiments(self, experiment_id: str, **kwargs: Any) -> Any:
+        """Delete an experiment."""
+        path = f"/_plugins/_search_relevance/experiments/{experiment_id}"
+        return self._client.transport.perform_request("DELETE", path, params=kwargs)
+
+    def get_stats(self, stat: str | None = None, **kwargs: Any) -> Any:
+        """Get search relevance statistics."""
+        if stat:
+            path = f"/_plugins/_search_relevance/stats/{stat}"
+        else:
+            path = "/_plugins/_search_relevance/stats"
+        return self._client.transport.perform_request("GET", path, params=kwargs)
+
+    def get_node_stats(
+        self, node_id: str, stat: str | None = None, **kwargs: Any
+    ) -> Any:
+        """Get node-specific search relevance statistics."""
+        if stat:
+            path = f"/_plugins/_search_relevance/stats/{node_id}/{stat}"
+        else:
+            path = f"/_plugins/_search_relevance/stats/{node_id}"
+        return self._client.transport.perform_request("GET", path, params=kwargs)
+
+
+class OpenSearchClientManager:
+    """Manages OpenSearch client connection with search_relevance plugin support."""
+
+    def __init__(
+        self,
+        opensearch_url: str | None = None,
+        username: str = "admin",
+        password: str = "admin",
+        verify_certs: bool = False,
+        ssl_show_warn: bool = False,
+        pool_maxsize: int = 20,
+        timeout: int = 30,
+    ) -> None:
+        """
+        Initialize OpenSearch client manager.
+
+        Args:
+            opensearch_url: OpenSearch cluster URL
+            username: Authentication username
+            password: Authentication password
+            verify_certs: Whether to verify SSL certificates
+            ssl_show_warn: Whether to show SSL warnings
+            pool_maxsize: Maximum number of connections in the pool (default: 20)
+            timeout: Connection timeout in seconds (default: 30)
+        """
+        self.opensearch_url = opensearch_url or os.getenv(
+            "OPENSEARCH_URL",
+            "http://localhost:9200",
+        )
+        self.username = username
+        self.password = password
+        self.verify_certs = verify_certs
+        self.ssl_show_warn = ssl_show_warn
+        self.pool_maxsize = pool_maxsize
+        self.timeout = timeout
+        self.client: OpenSearch | None = None
+        self._search_relevance_client: SearchRelevanceClient | None = None
+
+    def connect(self) -> OpenSearch:
+        """
+        Connect to OpenSearch and return the client.
+
+        Returns:
+            OpenSearch: Configured OpenSearch client instance
+        """
+        if self.client is None:
+            # Parse URL to extract host and port
+            url_parts = self.opensearch_url.replace("http://", "").replace(
+                "https://", ""
+            )
+            host_port = url_parts.split(":")
+            host = host_port[0]
+            port = (
+                int(host_port[1].split("/")[0])
+                if len(host_port) > 1
+                else (443 if "https" in self.opensearch_url else 9200)
+            )
+
+            self.client = OpenSearch(
+                hosts=[{"host": host, "port": port}],
+                http_auth=(self.username, self.password),
+                use_ssl="https" in self.opensearch_url,
+                verify_certs=self.verify_certs,
+                ssl_show_warn=self.ssl_show_warn,
+                pool_maxsize=self.pool_maxsize,
+                timeout=self.timeout,
+            )
+            log_info_event(
+                logger,
+                f"[OpenSearch] Connected to {self.opensearch_url} (pool_maxsize={self.pool_maxsize}, timeout={self.timeout}s)",
+                "opensearch.connected",
+                opensearch_url=self.opensearch_url,
+                pool_maxsize=self.pool_maxsize,
+                timeout=self.timeout,
+            )
+
+            # Initialize search_relevance client
+            self._search_relevance_client = SearchRelevanceClient(self.client)
+
+        return self.client
+
+    def get_client(self) -> OpenSearch:
+        """
+        Get the OpenSearch client, connecting if necessary.
+
+        Returns:
+            OpenSearch: The OpenSearch client instance
+        """
+        if self.client is None:
+            self.connect()
+        return self.client
+
+    def get_search_relevance_client(self) -> SearchRelevanceClient:
+        """
+        Get the search_relevance plugin client.
+
+        Returns:
+            SearchRelevanceClient: The search_relevance plugin client
+        """
+        if self._search_relevance_client is None:
+            self.connect()
+        return self._search_relevance_client
+
+    def disconnect(self) -> None:
+        """Close the OpenSearch connection."""
+        if self.client:
+            self.client.close()
+            log_info_event(
+                logger, "[OpenSearch] Connection closed", "opensearch.connection_closed"
+            )
+            self.client = None
+            self._search_relevance_client = None
+
+
+# Global client manager instance
+_client_manager: OpenSearchClientManager | None = None
+
+
+def get_client_manager(
+    opensearch_url: str | None = None,
+    username: str = "admin",
+    password: str = "admin",
+) -> OpenSearchClientManager:
+    """
+    Get or create the global OpenSearch client manager.
+
+    Connection options (verify_certs, ssl_show_warn, pool_maxsize, timeout)
+    are not accepted here; the created manager uses OpenSearchClientManager
+    defaults. Subsequent calls return the same instance; URL/username/password
+    are ignored after the first call.
+
+    Args:
+        opensearch_url: OpenSearch cluster URL
+        username: Authentication username
+        password: Authentication password
+
+    Returns:
+        OpenSearchClientManager: The client manager instance
+    """
+    global _client_manager
+    if _client_manager is None:
+        _client_manager = OpenSearchClientManager(
+            opensearch_url=opensearch_url,
+            username=username,
+            password=password,
+        )
+    return _client_manager


### PR DESCRIPTION
### Description
Tests showed significant deviations of the MCP-based LLM-driven derivation of engagement metrics and those calculated deterministically via direct index calls. This PR adds back the functionality of utilizing explicit function calls, and explicitly setting priority to use function calls before MCP usage in the agent’s system prompt. This fixes related tests.
One option that deserves trying out before merging would be giving explicit calculation criteria for distinct metrics in the agent’s system prompt.

NOTE: this fix so far includes the need to have env properties OPENSEARCH_URL, OPENSEARCH_PASSWORD, OPENSEARCH_USERNAME set since this is used as basic auth on making the opensearch requests in the function tools. This might need adjustment to auth handling.

### Issues Resolved
Failed tests due to strong deviations of LLM-based engagement derivation via MCP and direct function calls indicating 
lack of accuracy and/or lack of sufficient calculation instructions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
