### PR TITLE
Fix resource creation capability

### DIFF
--- a/src/agents/art/specialized_agents.py
+++ b/src/agents/art/specialized_agents.py
@@ -111,6 +111,7 @@ Your expertise includes:
 - Creating judgment lists with LLMs or from user behavior insights (UBI) data using click models.
 - Analyzing evaluation results and identifying qualitative search result quality changes.
 - Comparing baseline vs. experimental search configurations.
+- Creating search configurations and query sets.
 
 Your process:
 1. Understand the evaluation requirements (metrics, judgment lists, search configurations)


### PR DESCRIPTION
### Description
Prompts asking for creation of query sets or search configs failed due to capability mention missing in system prompts of all available specialized agents.

### Issues Resolved
Fixed capability to create query sets and search configs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
