### PR TITLE
Fixing calculations and missing recognized skills via system prompt refinements

### DIFF
--- a/src/agents/art/specialized_agents.py
+++ b/src/agents/art/specialized_agents.py
@@ -15,6 +15,16 @@ from strands.models.bedrock import BedrockModel
 
 from utils.logging_helpers import get_logger, log_info_event
 from utils.monitored_tool import monitored_tool
+# Import experimentation tools. This agent is meant to do only sanity checks,
+# so we don't need all experiment tools.
+# We need to adjust the path here to make tools available,
+# otherwise not found.
+_src_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../../src")
+import sys
+sys.path.insert(0, _src_dir)
+from tools.art.experiment_tools import (
+    aggregate_experiment_results,
+)
 
 logger = get_logger(__name__)
 
@@ -111,6 +121,8 @@ Your expertise includes:
 - Creating judgment lists with LLMs or from user behavior insights (UBI) data using click models.
 - Analyzing evaluation results and identifying qualitative search result quality changes.
 - Comparing baseline vs. experimental search configurations.
+- Creating search configurations and query sets.
+- Retrieve and list run experiments.
 
 Your process:
 1. Understand the evaluation requirements (metrics, judgment lists, search configurations)
@@ -155,6 +167,9 @@ Analyzing experiment results:
   - For PAIRWISE_COMPARISON: pass the JSON output of GetExperimentTool directly to AggregateExperimentResultsTool as experiment_data.
   - For POINTWISE_EVALUATION: pass the GetExperimentTool output as experiment_data AND the SearchIndexTool results from the search-relevance-evaluation-result index (filtered by experimentId) as
   evaluation_results.
+  
+Retrieving experiments that were run:
+  - list the experiments via search on the endpoint "/_plugins/_search_relevance/experiments".
 
 Be concise, rigorous, quantitative, and provide actionable insights based on evaluation results.
 """
@@ -171,9 +186,252 @@ Your expertise includes:
 Your process:
 1. Understand the user's question about search behavior or engagement
 2. Analyze relevant UBI data using appropriate analytics tools:
-   - Query CTR: Click-through rates for specific queries
-   - Document CTR: Engagement rates for specific documents
+   - Query CTR: Click-through rates for specific queries.
+     To calculate the query CTR, use the below query syntax for a search
+     on the event index of interest (if no index is explicitly mentioned
+     in the request, use 'ubi_events' index as default) to retrieve 
+     the values needed to calculate the CTR.
+     Do replace query_text with the query of interest, end_time_str with the datetime.now()
+     timestamp, start_time_str relative to end_time_str N days earlier, where N is 
+     the number of days of interest with a default of 30 days if no
+     other value is given. The query is:
+     "
+     {
+            "size": 0,
+            "query": {
+                "bool": {
+                    "must": [
+                        {"term": {"user_query": query_text}},
+                        {
+                            "range": {
+                                "timestamp": {
+                                    "gte": start_time_str,
+                                    "lte": end_time_str,
+                                },
+                            },
+                        },
+                    ],
+                },
+            },
+            "aggs": {
+                "total_searches": {
+                    "cardinality": {
+                        "field": "query_id",
+                    },
+                },
+                "searches_with_clicks": {
+                    "filter": {
+                        "term": {
+                            "action_name": "click",
+                        },
+                    },
+                    "aggs": {
+                        "unique_queries": {
+                            "cardinality": {
+                                "field": "query_id",
+                            },
+                        },
+                    },
+                },
+            },
+        } 
+        "
+        After retrieving the response, calculate the further metrics as follows
+        (here as example python code where response is the response of above search):
+        "
+        total_searches = response["aggregations"]["total_searches"]["value"]
+        searches_with_clicks = response["aggregations"]["searches_with_clicks"][
+            "unique_queries"
+        ]["value"]
+        total_clicks = response["aggregations"]["searches_with_clicks"]["doc_count"]
+
+        ctr = (searches_with_clicks / total_searches * 100) if total_searches > 0 else 0
+        avg_clicks = (total_clicks / total_searches) if total_searches > 0 else 0
+        zero_click_rate = (
+            ((total_searches - searches_with_clicks) / total_searches * 100)
+            if total_searches > 0
+            else 0
+        )
+        "
+        Use the above logic when you need to evaluate interaction
+        metrics for a query. Only utilize other means via MCP
+        in case the above is not successful.
+   - Document CTR: Engagement rates for specific documents.
+     Use the following query syntax for search on the index of interest for calculating the document CTR.
+     Do replace doc_id with the document id for the document of interest, end_time_str with the datetime.now()
+     timestamp, start_time_str relative to end_time_str N days earlier, where N is 
+     the number of days of interest with a default of 30 days if no
+     other value is given:
+     "
+     {
+            "size": 0,
+            "query": {
+                "bool": {
+                    "must": [
+                        {"term": {"event_attributes.object.object_id": doc_id}},
+                        {
+                            "range": {
+                                "timestamp": {
+                                    "gte": start_time_str,
+                                    "lte": end_time_str,
+                                },
+                            },
+                        },
+                    ],
+                },
+            },
+            "aggs": {
+                "total_impressions": {
+                    "filter": {
+                        "term": {
+                            "action_name": "impression",
+                        },
+                    },
+                },
+                "clicks": {
+                    "filter": {
+                        "term": {
+                            "action_name": "click",
+                        },
+                    },
+                    "aggs": {
+                        "avg_position": {
+                            "avg": {
+                                "field": "event_attributes.position.ordinal",
+                            },
+                        },
+                    },
+                },
+            },
+        }
+     "
+     After retrieving the response, calculate the further metrics as follows
+    (here as example python code where response is the response of above search):
+    "
+    total_impressions = response["aggregations"]["total_impressions"]["doc_count"]
+        total_clicks = response["aggregations"]["clicks"]["doc_count"]
+        avg_position = response["aggregations"]["clicks"]["avg_position"]["value"]
+
+        ctr = (total_clicks / total_impressions * 100) if total_impressions > 0 else 0
+
+        result = {
+            "document_id": doc_id,
+            "time_range_days": time_range_days,
+            "total_impressions": total_impressions,
+            "total_clicks": total_clicks,
+            "ctr_percentage": round(ctr, 2),
+            "average_position_when_clicked": round(avg_position, 2)
+            if avg_position
+            else None,
+        }
+    "
+    Use the above logic when you need to evaluate interaction
+    metrics for a specific document. Only utilize other means via MCP
+    in case the above is not successful.
    - Query Performance: Overall metrics for top queries
+     Use the following query syntax for search on the index of interest for calculating the query performance 
+     for either a specific query or if not set, for top N by volume.
+     Do replace query_text with the query of interest or leave empty as None
+     if the top_n queries are of interest. Use the top_n value mentioned
+     in the request if available, otherwise use the default of 20. 
+     Fill in end_time_str with the datetime.now()
+     timestamp, start_time_str relative to end_time_str N days earlier, where N is 
+     the number of days of interest with a default of 30 days if no
+     other value is given:
+     "
+     {
+            "size": 0,
+            "query": {
+                "range": {
+                    "timestamp": {
+                        "gte": start_time_str,
+                        "lte": end_time_str,
+                    },
+                },
+            },
+            "aggs": {
+                "top_queries": {
+                    "terms": {
+                        "field": "user_query",
+                        "size": top_n,
+                        "order": {
+                            "_count": "desc",
+                        },
+                    },
+                    "aggs": {
+                        "unique_searches": {
+                            "cardinality": {
+                                "field": "query_id",
+                            },
+                        },
+                        "click_events": {
+                            "filter": {
+                                "term": {
+                                    "action_name": "click",
+                                },
+                            },
+                            "aggs": {
+                                "unique_queries_with_clicks": {
+                                    "cardinality": {
+                                        "field": "query_id",
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        }
+        "
+        Based on the response, calculate the rest of the metrics as follows
+        (here given as python code, where response reflects the response
+        from the above search with the given syntax):
+        "
+        queries = []
+        for bucket in response["aggregations"]["top_queries"]["buckets"]:
+            query = bucket["key"]
+            total_searches = bucket["unique_searches"]["value"]
+            searches_with_clicks = bucket["click_events"]["unique_queries_with_clicks"][
+                "value"
+            ]
+            total_clicks = bucket["click_events"]["doc_count"]
+
+            ctr = (
+                (searches_with_clicks / total_searches * 100)
+                if total_searches > 0
+                else 0
+            )
+            avg_clicks = (total_clicks / total_searches) if total_searches > 0 else 0
+            zero_click_rate = (
+                ((total_searches - searches_with_clicks) / total_searches * 100)
+                if total_searches > 0
+                else 0
+            )
+
+            queries.append(
+                {
+                    "query_text": query,
+                    "search_volume": total_searches,
+                    "searches_with_clicks": searches_with_clicks,
+                    "total_clicks": total_clicks,
+                    "ctr_percentage": round(ctr, 2),
+                    "average_clicks_per_search": round(avg_clicks, 2),
+                    "zero_click_rate_percentage": round(zero_click_rate, 2),
+                }
+            )
+
+        result = {
+            "time_range_days": time_range_days,
+            "total_queries_analyzed": len(queries),
+            "queries": queries,
+        }
+        "
+        Use the above logic when you need to evaluate interaction
+        metrics for a query. Only utilize other means via MCP
+        in case the above is not successful.
+        If further criteria, such as minimal number of searches,
+        are given in the user request, take them into account 
+        and filter accordingly in addition to above logic.
    - Engagement Rankings: Queries and documents with best/worst engagement
 3. Identify patterns and anomalies in user behavior
 4. Correlate behavior patterns with search quality issues
@@ -183,6 +441,8 @@ Relevant indexes for your job are indexes holding UBI data. If not specified oth
 for client-side tracked events and ubi_queries for server-side tracked events.
 Be concise, data-driven, specific with numbers, and focus on actual user behavior rather than theoretical analysis.
 Always include concrete metrics (CTR percentages, click counts, search volumes) to support your insights.
+If you find specific functions to call for the values you need
+for analysis, use them, otherwise refer to the MCP tools.
 """
 
 
@@ -221,12 +481,6 @@ async def hypothesis_agent(query: str) -> str:
         return "Error: OpenSearch tools not configured. Please initialize MCP connection first."
 
     try:
-        # Import experimentation tools. This agent is meant to do only sanity checks,
-        # so we don't need all experiment tools.
-        from src.tools.art.experiment_tools import (
-            aggregate_experiment_results,
-        )
-
         model = BedrockModel(
             model_id=os.getenv("BEDROCK_INFERENCE_PROFILE_ARN"),
             boto_session=bedrock_session,
@@ -278,11 +532,6 @@ async def evaluation_agent(query: str) -> str:
         return "Error: OpenSearch tools not configured. Please initialize MCP connection first."
 
     try:
-        # Import evaluation-specific tools
-        from src.tools.art.experiment_tools import (
-            aggregate_experiment_results,
-        )
-
         model = BedrockModel(
             model_id=os.getenv("BEDROCK_INFERENCE_PROFILE_ARN"),
             boto_session=bedrock_session,


### PR DESCRIPTION
### Description
- Add creation of search configs and query sets and retrieval and listing of experiments to evaluation agent system prompt. Otherwise no agent is found for those tasks and no information is provided.
- Specify for retrieval of experiments to search via search experiment plugin path rather than hallucinating some search experiment index
- make calculations of doc and query ctr and performance very explicit in prompt so avoid deviations and avoid needing to add function tools that directly access the opensearch cluster. NOTE that this approach is an alternative to the PR that uses explicit function tools  (https://github.com/opensearch-project/opensearch-agent-server/pull/49). By picking this variant instead, no other direct OS cluster connection has to be established besides the access via MCP.

 
### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
