### PR TITLE
Fix failing tests after MCP client auth refactor (#57)

### DIFF
--- a/tests/integration/test_specialized_agents.py
+++ b/tests/integration/test_specialized_agents.py
@@ -28,22 +28,18 @@ def mock_get_emitter() -> Generator[None, None, None]:
 
 
 @pytest.fixture(autouse=True)
-def reset_opensearch_tools() -> Generator[None, None, None]:
-    """Reset _opensearch_tools before and after each test to ensure isolation."""
+def reset_mcp_client() -> Generator[None, None, None]:
+    """Reset _mcp_client before and after each test to ensure isolation."""
     # Save original state
-    original_tools = (
-        list(specialized_agents._opensearch_tools)
-        if specialized_agents._opensearch_tools
-        else []
-    )
+    original_client = specialized_agents._mcp_client
 
     # Reset before test
-    specialized_agents._opensearch_tools = []
+    specialized_agents._mcp_client = None
 
     yield
 
     # Restore original state after test
-    specialized_agents._opensearch_tools = original_tools
+    specialized_agents._mcp_client = original_client
 
 
 @pytest.mark.integration
@@ -52,14 +48,13 @@ class TestSetOpenSearchTools:
 
     @pytest.mark.asyncio
     async def test_set_opensearch_tools(self):
-        """Test that set_opensearch_tools sets the global tools variable."""
+        """Test that set_mcp_client sets the global mcp client variable."""
         from agents.art import specialized_agents
 
-        test_tools = [MagicMock(), MagicMock()]
-        specialized_agents.set_opensearch_tools(test_tools)
+        mock_client = MagicMock()
+        specialized_agents.set_mcp_client(mock_client)
 
-        assert specialized_agents._opensearch_tools == test_tools
-        assert len(specialized_agents._opensearch_tools) == 2
+        assert specialized_agents._mcp_client == mock_client
 
 
 @pytest.mark.integration
@@ -72,13 +67,13 @@ class TestHypothesisAgent:
         # autouse fixture ensures tools are empty
         result = await specialized_agents.hypothesis_agent("test query")
 
-        assert "Error: OpenSearch tools not configured" in result
+        assert "Error: MCPClient not configured" in result
 
     @pytest.mark.asyncio
     async def test_hypothesis_agent_success(self):
         """Test that hypothesis_agent creates agent and invokes successfully."""
         # Set tools
-        specialized_agents._opensearch_tools = [MagicMock()]
+        specialized_agents._mcp_client = MagicMock()
 
         mock_agent = MagicMock()
         mock_agent.invoke_async = AsyncMock(return_value="Test hypothesis response")
@@ -92,7 +87,7 @@ class TestHypothesisAgent:
     @pytest.mark.asyncio
     async def test_hypothesis_agent_rate_limit_error(self):
         """Test that hypothesis_agent handles rate limit errors."""
-        specialized_agents._opensearch_tools = [MagicMock()]
+        specialized_agents._mcp_client = MagicMock()
 
         mock_agent = MagicMock()
         mock_agent.invoke_async = AsyncMock(
@@ -109,7 +104,7 @@ class TestHypothesisAgent:
         """Test that hypothesis_agent handles general errors."""
         from agents.art import specialized_agents
 
-        specialized_agents._opensearch_tools = [MagicMock()]
+        specialized_agents._mcp_client = MagicMock()
 
         mock_agent = MagicMock()
         mock_agent.invoke_async = AsyncMock(side_effect=Exception("General error"))
@@ -133,14 +128,14 @@ class TestEvaluationAgent:
         # autouse fixture ensures tools are empty
         result = await specialized_agents.evaluation_agent("test query")
 
-        assert "Error: OpenSearch tools not configured" in result
+        assert "Error: MCPClient not configured" in result
 
     @pytest.mark.asyncio
     async def test_evaluation_agent_success(self):
         """Test that evaluation_agent creates agent and invokes successfully."""
         from agents.art import specialized_agents
 
-        specialized_agents._opensearch_tools = [MagicMock()]
+        specialized_agents._mcp_client = MagicMock()
 
         mock_agent = MagicMock()
         mock_agent.invoke_async = AsyncMock(return_value="Test evaluation response")
@@ -156,7 +151,7 @@ class TestEvaluationAgent:
         """Test that evaluation_agent handles rate limit errors."""
         from agents.art import specialized_agents
 
-        specialized_agents._opensearch_tools = [MagicMock()]
+        specialized_agents._mcp_client = MagicMock()
 
         mock_agent = MagicMock()
         mock_agent.invoke_async = AsyncMock(
@@ -173,7 +168,7 @@ class TestEvaluationAgent:
         """Test that evaluation_agent handles general errors (non-rate-limit)."""
         from agents.art import specialized_agents
 
-        specialized_agents._opensearch_tools = [MagicMock()]
+        specialized_agents._mcp_client = MagicMock()
 
         mock_agent = MagicMock()
         mock_agent.invoke_async = AsyncMock(side_effect=Exception("General error"))
@@ -197,14 +192,14 @@ class TestUserBehaviorAnalysisAgent:
         # autouse fixture ensures tools are empty
         result = await specialized_agents.user_behavior_analysis_agent("test query")
 
-        assert "Error: OpenSearch tools not configured" in result
+        assert "Error: MCPClient not configured" in result
 
     @pytest.mark.asyncio
     async def test_user_behavior_analysis_agent_success(self):
         """Test that user_behavior_analysis_agent creates agent and invokes successfully."""
         from agents.art import specialized_agents
 
-        specialized_agents._opensearch_tools = [MagicMock()]
+        specialized_agents._mcp_client = MagicMock()
 
         mock_agent = MagicMock()
         mock_agent.invoke_async = AsyncMock(return_value="Test UBI analysis response")
@@ -220,7 +215,7 @@ class TestUserBehaviorAnalysisAgent:
         """Test that user_behavior_analysis_agent handles errors."""
         from agents.art import specialized_agents
 
-        specialized_agents._opensearch_tools = [MagicMock()]
+        specialized_agents._mcp_client = MagicMock()
 
         mock_agent = MagicMock()
         mock_agent.invoke_async = AsyncMock(side_effect=Exception("Test error"))
@@ -236,7 +231,7 @@ class TestUserBehaviorAnalysisAgent:
         """Test that user_behavior_analysis_agent handles rate limit errors."""
         from agents.art import specialized_agents
 
-        specialized_agents._opensearch_tools = [MagicMock()]
+        specialized_agents._mcp_client = MagicMock()
 
         mock_agent = MagicMock()
         mock_agent.invoke_async = AsyncMock(
@@ -260,7 +255,7 @@ class TestSpecializedAgentsErrorHandling:
         """Test hypothesis agent when tool call fails during execution."""
         from agents.art import specialized_agents
 
-        specialized_agents._opensearch_tools = [MagicMock()]
+        specialized_agents._mcp_client = MagicMock()
 
         mock_agent = MagicMock()
         # Simulate tool failure during agent invocation
@@ -287,7 +282,7 @@ class TestSpecializedAgentsErrorHandling:
 
         from agents.art import specialized_agents
 
-        specialized_agents._opensearch_tools = [MagicMock()]
+        specialized_agents._mcp_client = MagicMock()
 
         mock_agent = MagicMock()
         # Simulate timeout during agent invocation
@@ -313,7 +308,7 @@ class TestSpecializedAgentsErrorHandling:
         """Test user behavior agent with missing UBI data."""
         from agents.art import specialized_agents
 
-        specialized_agents._opensearch_tools = [MagicMock()]
+        specialized_agents._mcp_client = MagicMock()
 
         mock_agent = MagicMock()
         # Simulate missing data scenario - agent should handle this gracefully
@@ -337,7 +332,7 @@ class TestSpecializedAgentsErrorHandling:
         """Test user behavior agent when UBI tools fail due to missing data."""
         from agents.art import specialized_agents
 
-        specialized_agents._opensearch_tools = [MagicMock()]
+        specialized_agents._mcp_client = MagicMock()
 
         mock_agent = MagicMock()
         # Simulate tool error when data is missing
@@ -359,18 +354,18 @@ class TestSpecializedAgentsErrorHandling:
         """Test agent initialization when tools are not available."""
         from agents.art import specialized_agents
 
-        # Ensure tools are empty (fixture handles this)
-        assert specialized_agents._opensearch_tools == []
+        # Ensure client is unset (fixture handles this)
+        assert specialized_agents._mcp_client is None
 
         # Test all agents without tools - should initialize with available tools, log warnings
         # Hypothesis agent
         result = await specialized_agents.hypothesis_agent("test query")
-        assert "Error: OpenSearch tools not configured" in result
+        assert "Error: MCPClient not configured" in result
 
         # Evaluation agent
         result = await specialized_agents.evaluation_agent("test query")
-        assert "Error: OpenSearch tools not configured" in result
+        assert "Error: MCPClient not configured" in result
 
         # User behavior agent
         result = await specialized_agents.user_behavior_analysis_agent("test query")
-        assert "Error: OpenSearch tools not configured" in result
+        assert "Error: MCPClient not configured" in result

--- a/tests/unit/test_specialized_agents_errors.py
+++ b/tests/unit/test_specialized_agents_errors.py
@@ -27,22 +27,18 @@ pytestmark = pytest.mark.unit
 
 
 @pytest.fixture(autouse=True)
-def reset_opensearch_tools() -> Generator[None, None, None]:
-    """Reset _opensearch_tools before and after each test to ensure isolation."""
+def reset_mcp_client() -> Generator[None, None, None]:
+    """Reset _mcp_client before and after each test to ensure isolation."""
     # Save original state
-    original_tools = (
-        list(specialized_agents._opensearch_tools)
-        if specialized_agents._opensearch_tools
-        else []
-    )
+    original_client = specialized_agents._mcp_client
 
     # Reset before test
-    specialized_agents._opensearch_tools = []
+    specialized_agents._mcp_client = None
 
     yield
 
     # Restore original state after test
-    specialized_agents._opensearch_tools = original_tools
+    specialized_agents._mcp_client = original_client
 
 
 @pytest.fixture(autouse=True)
@@ -59,7 +55,7 @@ class TestSpecializedAgentsErrors:
     async def test_hypothesis_agent_tool_failure(self):
         """Test hypothesis agent when tool call fails."""
         # Should handle tool errors gracefully
-        specialized_agents._opensearch_tools = [MagicMock()]
+        specialized_agents._mcp_client = MagicMock()
 
         mock_agent = MagicMock()
         # Simulate tool failure during agent invocation
@@ -81,7 +77,7 @@ class TestSpecializedAgentsErrors:
     async def test_evaluation_agent_timeout(self):
         """Test evaluation agent timeout handling."""
         # Should timeout gracefully, emit error event
-        specialized_agents._opensearch_tools = [MagicMock()]
+        specialized_agents._mcp_client = MagicMock()
 
         mock_agent = MagicMock()
         # Simulate timeout during agent invocation
@@ -108,7 +104,7 @@ class TestSpecializedAgentsErrors:
         # Should handle missing data gracefully
         from agents.art import specialized_agents
 
-        specialized_agents._opensearch_tools = [MagicMock()]
+        specialized_agents._mcp_client = MagicMock()
 
         mock_agent = MagicMock()
         # Simulate missing data scenario - agent should handle this gracefully
@@ -134,7 +130,7 @@ class TestSpecializedAgentsErrors:
         # Should handle tool errors due to missing data gracefully
         from agents.art import specialized_agents
 
-        specialized_agents._opensearch_tools = [MagicMock()]
+        specialized_agents._mcp_client = MagicMock()
 
         mock_agent = MagicMock()
         # Simulate tool error when data is missing
@@ -160,20 +156,20 @@ class TestSpecializedAgentsErrors:
         # The agent should return an error message, not crash
         from agents.art import specialized_agents
 
-        # Ensure tools are empty (fixture handles this)
-        assert specialized_agents._opensearch_tools == []
+        # Ensure client is unset (fixture handles this)
+        assert specialized_agents._mcp_client is None
 
         # Test hypothesis agent without tools
         result = await specialized_agents.hypothesis_agent("test query")
-        assert "Error: OpenSearch tools not configured" in result
+        assert "Error: MCPClient not configured" in result
 
         # Test evaluation agent without tools
         result = await specialized_agents.evaluation_agent("test query")
-        assert "Error: OpenSearch tools not configured" in result
+        assert "Error: MCPClient not configured" in result
 
         # Test user behavior agent without tools
         result = await specialized_agents.user_behavior_analysis_agent("test query")
-        assert "Error: OpenSearch tools not configured" in result
+        assert "Error: MCPClient not configured" in result
 
     @pytest.mark.asyncio
     async def test_hypothesis_agent_agent_creation_error(self):
@@ -181,7 +177,7 @@ class TestSpecializedAgentsErrors:
         # Should handle agent creation errors gracefully
         from agents.art import specialized_agents
 
-        specialized_agents._opensearch_tools = [MagicMock()]
+        specialized_agents._mcp_client = MagicMock()
 
         # Simulate Agent creation failure using ExitStack to handle many patches
         stack = ExitStack()
@@ -213,7 +209,7 @@ class TestSpecializedAgentsErrors:
         # Should handle connection errors gracefully
         from agents.art import specialized_agents
 
-        specialized_agents._opensearch_tools = [MagicMock()]
+        specialized_agents._mcp_client = MagicMock()
 
         mock_agent = MagicMock()
         mock_agent.invoke_async = AsyncMock(


### PR DESCRIPTION
### Description
Updates the test suite to match the API changes introduced in #57, which replaced `_opensearch_tools`/`set_opensearch_tools` with `_mcp_client`/`set_mcp_client`.

Changes:
- Replace `_opensearch_tools` references with `_mcp_client` in test fixtures and test cases
- Replace `set_opensearch_tools()` calls with `set_mcp_client()`
- Update error message assertions to match the new `"Error: MCPClient not configured"` message

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).