### PR TITLE
add ollama support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,10 +15,13 @@ AG_UI_CORS_ORIGINS=http://localhost:5601
 # AWS_ACCESS_KEY_ID=...
 # AWS_SECRET_ACCESS_KEY=...
 # AWS_REGION=us-east-1
-# BEDROCK_INFERENCE_PROFILE_ARN=...
+# BEDROCK_MODEL=us.anthropic.claude-sonnet-4-20250514-v1:0
+# BEDROCK_SMALL_MODEL=us.anthropic.claude-haiku-4-5-20251001-v1:0
 
 # Option 2: Ollama (local)
-# OLLAMA_MODEL=llama3
+# OLLAMA_HOST=http://localhost:11434
+# OLLAMA_MODEL=qwen3.5:27b
+# OLLAMA_SMALL_MODEL=qwen3.5:27b
 
 # Logging
 AG_UI_LOG_FORMAT=human

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Added
 - Support using Ollama as model provider
 - PPL reference skill and skills auto-discovery for the default agent
+
 ### Fixed
 - Default agent now respects `BEDROCK_INFERENCE_PROFILE_ARN` env var instead of silently falling back to a hardcoded Sonnet 4 model (fixes #94)
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Added
+- Support using Ollama as model provider
 - PPL reference skill and skills auto-discovery for the default agent
 ### Fixed
 - Default agent now respects `BEDROCK_INFERENCE_PROFILE_ARN` env var instead of silently falling back to a hardcoded Sonnet 4 model (fixes #94)

--- a/README.md
+++ b/README.md
@@ -89,19 +89,19 @@ AG_UI_AUTH_ENABLED=false
 # CORS (allow OpenSearch Dashboards origin)
 AG_UI_CORS_ORIGINS=http://localhost:5601
 
-# LLM Provider — choose one:
+# LLM Provider — uncomment the section for the provider you want to use:
 
 # Option 1: AWS Bedrock
-AWS_ACCESS_KEY_ID=your_access_key
-AWS_SECRET_ACCESS_KEY=your_secret_key
-AWS_REGION=us-east-1
-BEDROCK_MODEL=us.anthropic.claude-sonnet-4-20250514-v1:0
-BEDROCK_SMALL_MODEL=us.anthropic.claude-haiku-4-5-20251001-v1:0
+# AWS_ACCESS_KEY_ID=your_access_key
+# AWS_SECRET_ACCESS_KEY=your_secret_key
+# AWS_REGION=us-east-1
+# BEDROCK_MODEL=us.anthropic.claude-sonnet-4-20250514-v1:0
+# BEDROCK_SMALL_MODEL=us.anthropic.claude-haiku-4-5-20251001-v1:0
 
 # Option 2: Ollama
-OLLAMA_HOST=http://localhost:11434
-OLLAMA_MODEL=llama3
-OLLAMA_SMALL_MODEL=llama3
+# OLLAMA_HOST=http://localhost:11434
+# OLLAMA_MODEL=llama3
+# OLLAMA_SMALL_MODEL=llama3
 
 # Logging
 AG_UI_LOG_FORMAT=human

--- a/README.md
+++ b/README.md
@@ -89,14 +89,19 @@ AG_UI_AUTH_ENABLED=false
 # CORS (allow OpenSearch Dashboards origin)
 AG_UI_CORS_ORIGINS=http://localhost:5601
 
-# LLM Provider — Option 1: AWS Bedrock
+# LLM Provider — choose one:
+
+# Option 1: AWS Bedrock
 AWS_ACCESS_KEY_ID=your_access_key
 AWS_SECRET_ACCESS_KEY=your_secret_key
 AWS_REGION=us-east-1
-BEDROCK_INFERENCE_PROFILE_ARN=arn:aws:bedrock:...
+BEDROCK_MODEL=us.anthropic.claude-sonnet-4-20250514-v1:0
+BEDROCK_SMALL_MODEL=us.anthropic.claude-haiku-4-5-20251001-v1:0
 
-# LLM Provider — Option 2: Ollama (local)
+# Option 2: Ollama
+OLLAMA_HOST=http://localhost:11434
 OLLAMA_MODEL=llama3
+OLLAMA_SMALL_MODEL=llama3
 
 # Logging
 AG_UI_LOG_FORMAT=human

--- a/run_server.py
+++ b/run_server.py
@@ -31,9 +31,10 @@ from dotenv import load_dotenv
 load_dotenv()
 
 # Bridge AWS credentials from ~/.aws/credentials to env vars.
-# ART's agent_config.py reads AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY from
-# os.getenv() rather than using the default boto3 credential chain.
-if not os.getenv("AWS_ACCESS_KEY_ID"):
+# Only needed when using Bedrock (not Ollama).
+from utils.model_factory import get_provider  # noqa: E402
+
+if get_provider() == "bedrock" and not os.getenv("AWS_ACCESS_KEY_ID"):
     _cred_file = os.path.expanduser("~/.aws/credentials")
     if os.path.isfile(_cred_file):
         import configparser

--- a/src/agents/art/art_agent.py
+++ b/src/agents/art/art_agent.py
@@ -10,11 +10,9 @@ from __future__ import annotations
 
 import os
 
-import boto3
 import httpx
 from mcp.client.streamable_http import streamable_http_client
 from strands import Agent
-from strands.models.bedrock import BedrockModel
 from strands.tools.mcp import MCPClient
 
 from agents.art.specialized_agents import (
@@ -24,13 +22,10 @@ from agents.art.specialized_agents import (
     user_behavior_analysis_agent,
 )
 from utils.logging_helpers import get_logger, log_info_event
+from utils.model_factory import create_model
 from utils.obo_context import OboAuth
 
 logger = get_logger(__name__)
-
-# Default Bedrock model — same as Strands SDK default.
-# Used when BEDROCK_INFERENCE_PROFILE_ARN is not explicitly set.
-_DEFAULT_BEDROCK_MODEL_ID = "us.anthropic.claude-sonnet-4-20250514-v1:0"
 
 DEFAULT_MCP_SERVER_URL = "http://localhost:3001/mcp"
 
@@ -78,24 +73,6 @@ Be helpful, clear, and ensure the user gets complete answers by leveraging the r
 """
 
 
-def _get_aws_session() -> boto3.Session:
-    """Create a boto3 session using the default AWS credential provider chain.
-
-    Supports environment variables, ~/.aws/credentials, IAM roles,
-    EC2 instance profiles, ECS task roles, and temporary credentials.
-    """
-    return boto3.Session()
-
-
-def _create_orchestrator_model(inference_profile_arn: str) -> BedrockModel:
-    """Create a BedrockModel for the orchestrator."""
-    return BedrockModel(
-        model_id=inference_profile_arn,
-        boto_session=_get_aws_session(),
-        streaming=True,
-    )
-
-
 def create_art_agent(opensearch_url: str) -> Agent:
     """Create the ART orchestrator agent.
 
@@ -113,23 +90,6 @@ def create_art_agent(opensearch_url: str) -> Agent:
     Returns:
         A Strands Agent configured as the ART orchestrator.
     """
-    # Default BEDROCK_INFERENCE_PROFILE_ARN if not set so specialized agents
-    # can create their own BedrockModel instances without error.
-    if not os.getenv("BEDROCK_INFERENCE_PROFILE_ARN"):
-        os.environ["BEDROCK_INFERENCE_PROFILE_ARN"] = _DEFAULT_BEDROCK_MODEL_ID
-        log_info_event(
-            logger,
-            f"BEDROCK_INFERENCE_PROFILE_ARN not set, defaulting to {_DEFAULT_BEDROCK_MODEL_ID}",
-            "art_agent.default_model",
-            model_id=_DEFAULT_BEDROCK_MODEL_ID,
-        )
-
-    # Also default BEDROCK_HAIKU_INFERENCE_PROFILE_ARN (used by user_behavior_analysis_agent)
-    if not os.getenv("BEDROCK_HAIKU_INFERENCE_PROFILE_ARN"):
-        os.environ["BEDROCK_HAIKU_INFERENCE_PROFILE_ARN"] = _DEFAULT_BEDROCK_MODEL_ID
-
-    inference_profile_arn = os.environ["BEDROCK_INFERENCE_PROFILE_ARN"]
-
     log_info_event(
         logger,
         f"Initializing ART agent with OpenSearch at {opensearch_url}",
@@ -169,7 +129,7 @@ def create_art_agent(opensearch_url: str) -> Agent:
 
     # Build the orchestrator agent
     orchestrator = Agent(
-        model=_create_orchestrator_model(inference_profile_arn),
+        model=create_model(),
         system_prompt=ORCHESTRATOR_SYSTEM_PROMPT,
         tools=[
             user_behavior_analysis_agent,

--- a/src/agents/art/specialized_agents.py
+++ b/src/agents/art/specialized_agents.py
@@ -6,15 +6,13 @@ Following the "Agents as Tools" pattern with Strands SDK
 from __future__ import annotations
 
 import os
-from typing import Any
 
-import boto3
 from dotenv import load_dotenv
 from strands import Agent
-from strands.models.bedrock import BedrockModel
 from strands.tools.mcp import MCPClient
 
 from utils.logging_helpers import get_logger, log_info_event
+from utils.model_factory import create_model
 from utils.monitored_tool import monitored_tool
 # Import experimentation tools. This agent is meant to do only sanity checks,
 # so we don't need all experiment tools.
@@ -32,16 +30,6 @@ logger = get_logger(__name__)
 
 # Load environment variables
 load_dotenv()
-
-# Create boto3 session using the default AWS credential provider chain.
-# Supports environment variables, ~/.aws/credentials, IAM roles,
-# EC2 instance profiles, ECS task roles, and temporary credentials.
-bedrock_session = boto3.Session()
-
-# create_art_agent() sets BEDROCK_INFERENCE_PROFILE_ARN / BEDROCK_HAIKU_INFERENCE_PROFILE_ARN
-# as defaults *after* this module is imported, so module-level os.getenv() would
-# always return None when the env var is not set before server start.
-# Each agent function reads the env var at call time instead.
 
 # System prompts for specialized agents
 HYPOTHESIS_GENERATOR_SYSTEM_PROMPT = """You are an expert in generating search relevance improvement hypotheses.
@@ -310,16 +298,10 @@ async def hypothesis_agent(query: str) -> str:
         return "Error: MCP tools not configured. Please initialize MCP connection first."
 
     try:
-        model = BedrockModel(
-            model_id=os.getenv("BEDROCK_INFERENCE_PROFILE_ARN"),
-            boto_session=bedrock_session,
-            streaming=True,
-        )
-
         # Use resolved tools (not MCPClient directly) to avoid calling
         # start() on an already-running session.
         agent = Agent(
-            model=model,
+            model=create_model(),
             system_prompt=HYPOTHESIS_GENERATOR_SYSTEM_PROMPT,
             tools=[*_mcp_tools, aggregate_experiment_results],
         )
@@ -355,16 +337,10 @@ async def evaluation_agent(query: str) -> str:
         return "Error: MCP tools not configured. Please initialize MCP connection first."
 
     try:
-        model = BedrockModel(
-            model_id=os.getenv("BEDROCK_INFERENCE_PROFILE_ARN"),
-            boto_session=bedrock_session,
-            streaming=True,
-        )
-
         # Use resolved tools (not MCPClient directly) to avoid calling
         # start() on an already-running session.
         agent = Agent(
-            model=model,
+            model=create_model(),
             system_prompt=EVALUATION_AGENT_SYSTEM_PROMPT,
             tools=[*_mcp_tools, aggregate_experiment_results],
         )
@@ -400,16 +376,10 @@ async def user_behavior_analysis_agent(query: str) -> str:
         return "Error: MCP tools not configured. Please initialize MCP connection first."
 
     try:
-        model = BedrockModel(
-            model_id=os.getenv("BEDROCK_HAIKU_INFERENCE_PROFILE_ARN"),
-            boto_session=bedrock_session,
-            streaming=True,
-        )
-
         # Use resolved tools (not MCPClient directly) to avoid calling
         # start() on an already-running session.
         agent = Agent(
-            model=model,
+            model=create_model(tier="small"),
             system_prompt=USER_BEHAVIOR_ANALYSIS_AGENT_SYSTEM_PROMPT,
             tools=[*_mcp_tools, compute_ubi_metrics],
         )

--- a/src/agents/default_agent.py
+++ b/src/agents/default_agent.py
@@ -9,36 +9,17 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-import boto3
 import httpx
 from mcp.client.streamable_http import streamable_http_client
 from strands import Agent, AgentSkills, Skill
-from strands.models import BedrockModel
 from strands.tools.mcp import MCPClient
 
 from server.constants import DEFAULT_MCP_SERVER_URL
 from utils.logging_helpers import get_logger, log_info_event
+from utils.model_factory import create_model
 from utils.obo_context import OboAuth
 
 logger = get_logger(__name__)
-
-# Default Bedrock model — same as Strands SDK default.
-# Used when BEDROCK_INFERENCE_PROFILE_ARN is not explicitly set.
-_DEFAULT_BEDROCK_MODEL_ID = "us.anthropic.claude-sonnet-4-20250514-v1:0"
-
-
-def _get_aws_session() -> boto3.Session:
-    """Create a boto3 session using the default AWS credential provider chain."""
-    return boto3.Session()
-
-
-def _create_default_agent_model(inference_profile_arn: str) -> BedrockModel:
-    """Create a BedrockModel for the default agent."""
-    return BedrockModel(
-        model_id=inference_profile_arn,
-        boto_session=_get_aws_session(),
-        streaming=True,
-    )
 
 
 class LoggingAgentSkills(AgentSkills):
@@ -192,22 +173,9 @@ def create_default_agent(opensearch_url: str) -> Agent:
             skill_names=[s.name for s in skills],
         )
 
-    # Read Bedrock inference profile from env var, falling back to Strands default.
-    # Using a local variable (not os.environ mutation) — the default agent has no
-    # sub-agents that need to observe this fallback.
-    inference_profile_arn = os.getenv(
-        "BEDROCK_INFERENCE_PROFILE_ARN", _DEFAULT_BEDROCK_MODEL_ID
-    )
-    log_info_event(
-        logger,
-        f"Default agent using Bedrock inference profile: {inference_profile_arn}",
-        "default_agent.bedrock_model",
-        inference_profile_arn=inference_profile_arn,
-    )
-
     # Create agent with MCP tools and skills plugin
     agent = Agent(
-        model=_create_default_agent_model(inference_profile_arn),
+        model=create_model(),
         system_prompt=DEFAULT_SYSTEM_PROMPT,
         tools=tools,
         plugins=plugins,

--- a/src/server/ag_ui_app.py
+++ b/src/server/ag_ui_app.py
@@ -77,9 +77,10 @@ def _init_tracing() -> None:
     """Initialize OpenTelemetry tracing.
 
     Reads OTEL_EXPORTER_OTLP_ENDPOINT from the environment and configures:
-    - Strands SDK telemetry: agent invocations and tool call spans
-    - OpenInference Bedrock instrumentation: message content, tool inputs/outputs
-      in Phoenix-compatible OpenInference format
+    - Strands SDK telemetry (provider-agnostic): agent invocations, tool call
+      spans, and model invocation spans for any LLM provider.
+    - OpenInference Bedrock instrumentation (Bedrock only): enriches traces
+      with message content and tool inputs/outputs in Phoenix-compatible format.
     """
     try:
         from strands.telemetry import StrandsTelemetry
@@ -100,22 +101,27 @@ def _init_tracing() -> None:
         )
         return
 
-    try:
-        from openinference.instrumentation.bedrock import BedrockInstrumentor
+    # Bedrock-specific enrichment — adds message content and tool I/O detail
+    # to traces via OpenInference. Only applicable when using Bedrock.
+    from utils.model_factory import get_provider
 
-        BedrockInstrumentor().instrument()
-        log_info_event(
-            logger,
-            "✓ Bedrock instrumentation enabled: message content and tool I/O will appear in traces",
-            "ag_ui.bedrock_instrumentation_enabled",
-        )
-    except ImportError as e:
-        log_warning_event(
-            logger,
-            f"✗ Bedrock instrumentation not available (missing openinference-instrumentation-bedrock): {e}",
-            "ag_ui.bedrock_instrumentation_unavailable",
-            error=str(e),
-        )
+    if get_provider() == "bedrock":
+        try:
+            from openinference.instrumentation.bedrock import BedrockInstrumentor
+
+            BedrockInstrumentor().instrument()
+            log_info_event(
+                logger,
+                "✓ Bedrock instrumentation enabled: message content and tool I/O will appear in traces",
+                "ag_ui.bedrock_instrumentation_enabled",
+            )
+        except ImportError as e:
+            log_warning_event(
+                logger,
+                f"✗ Bedrock instrumentation not available (missing openinference-instrumentation-bedrock): {e}",
+                "ag_ui.bedrock_instrumentation_unavailable",
+                error=str(e),
+            )
 
 
 # Set by lifespan at startup; used by routes at request time.

--- a/src/utils/model_factory.py
+++ b/src/utils/model_factory.py
@@ -11,6 +11,7 @@ All provider-specific imports are lazy so that missing dependencies (e.g.
 from __future__ import annotations
 
 import os
+from typing import Literal
 
 from utils.logging_helpers import get_logger, log_info_event
 
@@ -20,7 +21,7 @@ logger = get_logger(__name__)
 _DEFAULT_BEDROCK_MODEL_ID = "us.anthropic.claude-sonnet-4-20250514-v1:0"
 
 
-def get_provider() -> str:
+def get_provider() -> Literal["ollama", "bedrock"]:
     """Return the active LLM provider name: ``"ollama"`` or ``"bedrock"``."""
     return "ollama" if os.getenv("OLLAMA_MODEL") else "bedrock"
 
@@ -46,13 +47,11 @@ def create_model(*, tier: str = "default"):
         else:
             model_id = os.getenv("OLLAMA_MODEL")
 
-        log_info_event(
-            logger,
-            f"Creating OllamaModel (tier={tier}, model={model_id}, host={host})",
-            "model_factory.ollama",
-            tier=tier,
-            model_id=model_id,
-            host=host,
+        logger.debug(
+            "Creating OllamaModel (tier=%s, model=%s, host=%s)",
+            tier,
+            model_id,
+            host,
         )
         return OllamaModel(host=host, model_id=model_id)
 
@@ -61,9 +60,19 @@ def create_model(*, tier: str = "default"):
     from strands.models.bedrock import BedrockModel
 
     if tier == "small":
-        model_id = os.getenv("BEDROCK_SMALL_MODEL") or os.getenv("BEDROCK_MODEL") or _DEFAULT_BEDROCK_MODEL_ID
+        model_id = (
+            os.getenv("BEDROCK_SMALL_MODEL")
+            or os.getenv("BEDROCK_HAIKU_INFERENCE_PROFILE_ARN")
+            or os.getenv("BEDROCK_MODEL")
+            or os.getenv("BEDROCK_INFERENCE_PROFILE_ARN")
+            or _DEFAULT_BEDROCK_MODEL_ID
+        )
     else:
-        model_id = os.getenv("BEDROCK_MODEL") or _DEFAULT_BEDROCK_MODEL_ID
+        model_id = (
+            os.getenv("BEDROCK_MODEL")
+            or os.getenv("BEDROCK_INFERENCE_PROFILE_ARN")
+            or _DEFAULT_BEDROCK_MODEL_ID
+        )
 
     log_info_event(
         logger,

--- a/src/utils/model_factory.py
+++ b/src/utils/model_factory.py
@@ -1,0 +1,79 @@
+"""LLM model factory — creates the right model based on environment config.
+
+Auto-detects the provider from environment variables:
+- If ``OLLAMA_MODEL`` is set → Ollama
+- Otherwise → AWS Bedrock (backward-compatible default)
+
+All provider-specific imports are lazy so that missing dependencies (e.g.
+``boto3`` when using Ollama) never cause import-time failures.
+"""
+
+from __future__ import annotations
+
+import os
+
+from utils.logging_helpers import get_logger, log_info_event
+
+logger = get_logger(__name__)
+
+# Fallback Bedrock model when env vars are not set.
+_DEFAULT_BEDROCK_MODEL_ID = "us.anthropic.claude-sonnet-4-20250514-v1:0"
+
+
+def get_provider() -> str:
+    """Return the active LLM provider name: ``"ollama"`` or ``"bedrock"``."""
+    return "ollama" if os.getenv("OLLAMA_MODEL") else "bedrock"
+
+
+def create_model(*, tier: str = "default"):
+    """Create an LLM model instance for the active provider.
+
+    Args:
+        tier: ``"default"`` for the primary model or ``"small"`` for a
+            cheaper / smaller model (used by user_behavior_analysis_agent).
+
+    Returns:
+        A Strands-compatible model (``BedrockModel`` or ``OllamaModel``).
+    """
+    provider = get_provider()
+
+    if provider == "ollama":
+        from strands.models.ollama import OllamaModel
+
+        host = os.getenv("OLLAMA_HOST", "http://localhost:11434")
+        if tier == "small":
+            model_id = os.getenv("OLLAMA_SMALL_MODEL") or os.getenv("OLLAMA_MODEL")
+        else:
+            model_id = os.getenv("OLLAMA_MODEL")
+
+        log_info_event(
+            logger,
+            f"Creating OllamaModel (tier={tier}, model={model_id}, host={host})",
+            "model_factory.ollama",
+            tier=tier,
+            model_id=model_id,
+            host=host,
+        )
+        return OllamaModel(host=host, model_id=model_id)
+
+    # Default: Bedrock
+    import boto3
+    from strands.models.bedrock import BedrockModel
+
+    if tier == "small":
+        model_id = os.getenv("BEDROCK_SMALL_MODEL") or os.getenv("BEDROCK_MODEL") or _DEFAULT_BEDROCK_MODEL_ID
+    else:
+        model_id = os.getenv("BEDROCK_MODEL") or _DEFAULT_BEDROCK_MODEL_ID
+
+    log_info_event(
+        logger,
+        f"Creating BedrockModel (tier={tier}, model={model_id})",
+        "model_factory.bedrock",
+        tier=tier,
+        model_id=model_id,
+    )
+    return BedrockModel(
+        model_id=model_id,
+        boto_session=boto3.Session(),
+        streaming=True,
+    )

--- a/tests/helpers/specialized_agents_helpers.py
+++ b/tests/helpers/specialized_agents_helpers.py
@@ -23,8 +23,7 @@ def patch_hypothesis_agent_dependencies(mock_agent: MagicMock) -> ExitStack:
     stack.enter_context(
         patch("agents.art.specialized_agents.Agent", return_value=mock_agent)
     )
-    stack.enter_context(patch("agents.art.specialized_agents.BedrockModel"))
-    stack.enter_context(patch("agents.art.specialized_agents.bedrock_session"))
+    stack.enter_context(patch("agents.art.specialized_agents.create_model"))
     stack.enter_context(patch("tools.art.experiment_tools.aggregate_experiment_results"))
     return stack
 
@@ -42,8 +41,7 @@ def patch_evaluation_agent_dependencies(mock_agent: MagicMock) -> ExitStack:
     stack.enter_context(
         patch("agents.art.specialized_agents.Agent", return_value=mock_agent)
     )
-    stack.enter_context(patch("agents.art.specialized_agents.BedrockModel"))
-    stack.enter_context(patch("agents.art.specialized_agents.bedrock_session"))
+    stack.enter_context(patch("agents.art.specialized_agents.create_model"))
     stack.enter_context(patch("tools.art.experiment_tools.aggregate_experiment_results"))
     return stack
 
@@ -61,6 +59,5 @@ def patch_ubi_agent_dependencies(mock_agent: MagicMock) -> ExitStack:
     stack.enter_context(
         patch("agents.art.specialized_agents.Agent", return_value=mock_agent)
     )
-    stack.enter_context(patch("agents.art.specialized_agents.BedrockModel"))
-    stack.enter_context(patch("agents.art.specialized_agents.bedrock_session"))
+    stack.enter_context(patch("agents.art.specialized_agents.create_model"))
     return stack

--- a/tests/unit/test_default_agent.py
+++ b/tests/unit/test_default_agent.py
@@ -18,7 +18,6 @@ from strands import Skill
 
 from agents import default_agent
 from agents.default_agent import (
-    _DEFAULT_BEDROCK_MODEL_ID,
     LoggingAgentSkills,
     _load_all_skills,
     create_default_agent,
@@ -219,55 +218,3 @@ class TestLoggingAgentSkills:
         call_args = mock_agent.state.set.call_args
         assert call_args.args[0] == "agent_skills"
         assert call_args.args[1] == {"activated_skills": ["my-skill"]}
-
-
-@pytest.mark.usefixtures("patch_mcp")
-class TestDefaultAgentModelSelection:
-    """Group 4 — Bedrock model selection via ``BEDROCK_INFERENCE_PROFILE_ARN``.
-
-    Regression coverage for issue #94: the default agent must respect the
-    ``BEDROCK_INFERENCE_PROFILE_ARN`` env var and fall back to the documented
-    Strands default when it is unset.
-    """
-
-    def test_uses_inference_profile_arn_from_env(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """When ``BEDROCK_INFERENCE_PROFILE_ARN`` is set, the agent uses that ARN."""
-        test_arn = (
-            "arn:aws:bedrock:eu-west-1:123456789012:inference-profile/"
-            "eu.anthropic.claude-haiku-4-5-20251001-v1:0"
-        )
-        monkeypatch.setenv("BEDROCK_INFERENCE_PROFILE_ARN", test_arn)
-
-        with (
-            patch("agents.default_agent._load_all_skills", return_value=[]),
-            patch("agents.default_agent.BedrockModel") as mock_bedrock_cls,
-            patch("agents.default_agent._get_aws_session") as mock_session_fn,
-        ):
-            create_default_agent("http://localhost:9200")
-
-        mock_bedrock_cls.assert_called_once_with(
-            model_id=test_arn,
-            boto_session=mock_session_fn.return_value,
-            streaming=True,
-        )
-
-    def test_falls_back_to_default_when_env_var_unset(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """When ``BEDROCK_INFERENCE_PROFILE_ARN`` is unset, falls back to default."""
-        monkeypatch.delenv("BEDROCK_INFERENCE_PROFILE_ARN", raising=False)
-
-        with (
-            patch("agents.default_agent._load_all_skills", return_value=[]),
-            patch("agents.default_agent.BedrockModel") as mock_bedrock_cls,
-            patch("agents.default_agent._get_aws_session") as mock_session_fn,
-        ):
-            create_default_agent("http://localhost:9200")
-
-        mock_bedrock_cls.assert_called_once_with(
-            model_id=_DEFAULT_BEDROCK_MODEL_ID,
-            boto_session=mock_session_fn.return_value,
-            streaming=True,
-        )

--- a/tests/unit/test_model_factory.py
+++ b/tests/unit/test_model_factory.py
@@ -69,6 +69,8 @@ class TestCreateModelBedrockFallbacks:
         monkeypatch.delenv("OLLAMA_MODEL", raising=False)
         monkeypatch.delenv("BEDROCK_MODEL", raising=False)
         monkeypatch.delenv("BEDROCK_SMALL_MODEL", raising=False)
+        monkeypatch.delenv("BEDROCK_INFERENCE_PROFILE_ARN", raising=False)
+        monkeypatch.delenv("BEDROCK_HAIKU_INFERENCE_PROFILE_ARN", raising=False)
 
     @patch("strands.models.bedrock.BedrockModel.__init__", return_value=None)
     @patch("boto3.Session")

--- a/tests/unit/test_model_factory.py
+++ b/tests/unit/test_model_factory.py
@@ -1,0 +1,112 @@
+"""Unit tests for the LLM model factory."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from utils.model_factory import create_model, get_provider
+
+pytestmark = pytest.mark.unit
+
+
+class TestGetProvider:
+    """Tests for provider auto-detection."""
+
+    def test_returns_bedrock_by_default(self, monkeypatch):
+        monkeypatch.delenv("OLLAMA_MODEL", raising=False)
+        assert get_provider() == "bedrock"
+
+    def test_returns_ollama_when_ollama_model_set(self, monkeypatch):
+        monkeypatch.setenv("OLLAMA_MODEL", "llama3")
+        assert get_provider() == "ollama"
+
+
+class TestCreateModelBedrock:
+    """Tests for Bedrock model creation."""
+
+    @pytest.fixture(autouse=True)
+    def _use_bedrock(self, monkeypatch):
+        monkeypatch.delenv("OLLAMA_MODEL", raising=False)
+        monkeypatch.setenv("BEDROCK_MODEL", "arn:aws:bedrock:us-east-1:123:model/test")
+        monkeypatch.setenv("BEDROCK_SMALL_MODEL", "arn:aws:bedrock:us-east-1:123:model/haiku")
+
+    @patch("strands.models.bedrock.BedrockModel.__init__", return_value=None)
+    @patch("boto3.Session")
+    def test_creates_default_bedrock_model(self, mock_session_cls, mock_init):
+        mock_session = MagicMock()
+        mock_session_cls.return_value = mock_session
+
+        create_model()
+
+        mock_init.assert_called_once_with(
+            model_id="arn:aws:bedrock:us-east-1:123:model/test",
+            boto_session=mock_session,
+            streaming=True,
+        )
+
+    @patch("strands.models.bedrock.BedrockModel.__init__", return_value=None)
+    @patch("boto3.Session")
+    def test_creates_small_bedrock_model(self, mock_session_cls, mock_init):
+        mock_session = MagicMock()
+        mock_session_cls.return_value = mock_session
+
+        create_model(tier="small")
+
+        mock_init.assert_called_once_with(
+            model_id="arn:aws:bedrock:us-east-1:123:model/haiku",
+            boto_session=mock_session,
+            streaming=True,
+        )
+
+
+class TestCreateModelOllama:
+    """Tests for Ollama model creation."""
+
+    @pytest.fixture(autouse=True)
+    def _use_ollama(self, monkeypatch):
+        monkeypatch.setenv("OLLAMA_MODEL", "llama3")
+        monkeypatch.delenv("OLLAMA_SMALL_MODEL", raising=False)
+        monkeypatch.delenv("OLLAMA_HOST", raising=False)
+
+    @patch("strands.models.ollama.OllamaModel.__init__", return_value=None)
+    def test_creates_default_ollama_model(self, mock_init):
+        create_model()
+
+        mock_init.assert_called_once_with(
+            host="http://localhost:11434",
+            model_id="llama3",
+        )
+
+    @patch("strands.models.ollama.OllamaModel.__init__", return_value=None)
+    def test_creates_small_ollama_model_fallback(self, mock_init):
+        """Small tier falls back to OLLAMA_MODEL when OLLAMA_SMALL_MODEL is not set."""
+        create_model(tier="small")
+
+        mock_init.assert_called_once_with(
+            host="http://localhost:11434",
+            model_id="llama3",
+        )
+
+    @patch("strands.models.ollama.OllamaModel.__init__", return_value=None)
+    def test_creates_small_ollama_model_explicit(self, mock_init, monkeypatch):
+        monkeypatch.setenv("OLLAMA_SMALL_MODEL", "phi3")
+
+        create_model(tier="small")
+
+        mock_init.assert_called_once_with(
+            host="http://localhost:11434",
+            model_id="phi3",
+        )
+
+    @patch("strands.models.ollama.OllamaModel.__init__", return_value=None)
+    def test_uses_custom_host(self, mock_init, monkeypatch):
+        monkeypatch.setenv("OLLAMA_HOST", "http://remote:11434")
+
+        create_model()
+
+        mock_init.assert_called_once_with(
+            host="http://remote:11434",
+            model_id="llama3",
+        )

--- a/tests/unit/test_model_factory.py
+++ b/tests/unit/test_model_factory.py
@@ -61,6 +61,94 @@ class TestCreateModelBedrock:
         )
 
 
+class TestCreateModelBedrockFallbacks:
+    """Tests for Bedrock model creation fallback chain."""
+
+    @pytest.fixture(autouse=True)
+    def _no_ollama(self, monkeypatch):
+        monkeypatch.delenv("OLLAMA_MODEL", raising=False)
+        monkeypatch.delenv("BEDROCK_MODEL", raising=False)
+        monkeypatch.delenv("BEDROCK_SMALL_MODEL", raising=False)
+
+    @patch("strands.models.bedrock.BedrockModel.__init__", return_value=None)
+    @patch("boto3.Session")
+    def test_default_tier_falls_back_to_default_model_id(self, mock_session_cls, mock_init):
+        """Default tier with no env vars uses _DEFAULT_BEDROCK_MODEL_ID."""
+        mock_session = MagicMock()
+        mock_session_cls.return_value = mock_session
+
+        create_model()
+
+        mock_init.assert_called_once_with(
+            model_id="us.anthropic.claude-sonnet-4-20250514-v1:0",
+            boto_session=mock_session,
+            streaming=True,
+        )
+
+    @patch("strands.models.bedrock.BedrockModel.__init__", return_value=None)
+    @patch("boto3.Session")
+    def test_small_tier_falls_back_to_bedrock_model(self, mock_session_cls, mock_init, monkeypatch):
+        """Small tier with only BEDROCK_MODEL set falls back to it."""
+        monkeypatch.setenv("BEDROCK_MODEL", "arn:aws:bedrock:us-east-1:123:model/sonnet")
+        mock_session = MagicMock()
+        mock_session_cls.return_value = mock_session
+
+        create_model(tier="small")
+
+        mock_init.assert_called_once_with(
+            model_id="arn:aws:bedrock:us-east-1:123:model/sonnet",
+            boto_session=mock_session,
+            streaming=True,
+        )
+
+    @patch("strands.models.bedrock.BedrockModel.__init__", return_value=None)
+    @patch("boto3.Session")
+    def test_small_tier_falls_back_to_default_model_id(self, mock_session_cls, mock_init):
+        """Small tier with neither env var set uses _DEFAULT_BEDROCK_MODEL_ID."""
+        mock_session = MagicMock()
+        mock_session_cls.return_value = mock_session
+
+        create_model(tier="small")
+
+        mock_init.assert_called_once_with(
+            model_id="us.anthropic.claude-sonnet-4-20250514-v1:0",
+            boto_session=mock_session,
+            streaming=True,
+        )
+
+    @patch("strands.models.bedrock.BedrockModel.__init__", return_value=None)
+    @patch("boto3.Session")
+    def test_default_tier_falls_back_to_legacy_env_var(self, mock_session_cls, mock_init, monkeypatch):
+        """Default tier with legacy BEDROCK_INFERENCE_PROFILE_ARN still works."""
+        monkeypatch.setenv("BEDROCK_INFERENCE_PROFILE_ARN", "arn:aws:bedrock:us-east-1:123:inference-profile/my-profile")
+        mock_session = MagicMock()
+        mock_session_cls.return_value = mock_session
+
+        create_model()
+
+        mock_init.assert_called_once_with(
+            model_id="arn:aws:bedrock:us-east-1:123:inference-profile/my-profile",
+            boto_session=mock_session,
+            streaming=True,
+        )
+
+    @patch("strands.models.bedrock.BedrockModel.__init__", return_value=None)
+    @patch("boto3.Session")
+    def test_small_tier_falls_back_to_legacy_haiku_env_var(self, mock_session_cls, mock_init, monkeypatch):
+        """Small tier with legacy BEDROCK_HAIKU_INFERENCE_PROFILE_ARN still works."""
+        monkeypatch.setenv("BEDROCK_HAIKU_INFERENCE_PROFILE_ARN", "arn:aws:bedrock:us-east-1:123:inference-profile/haiku")
+        mock_session = MagicMock()
+        mock_session_cls.return_value = mock_session
+
+        create_model(tier="small")
+
+        mock_init.assert_called_once_with(
+            model_id="arn:aws:bedrock:us-east-1:123:inference-profile/haiku",
+            boto_session=mock_session,
+            streaming=True,
+        )
+
+
 class TestCreateModelOllama:
     """Tests for Ollama model creation."""
 

--- a/tests/unit/test_specialized_agents_errors.py
+++ b/tests/unit/test_specialized_agents_errors.py
@@ -193,8 +193,7 @@ class TestSpecializedAgentsErrors:
         mock_agent_class = stack.enter_context(
             patch("agents.art.specialized_agents.Agent")
         )
-        stack.enter_context(patch("agents.art.specialized_agents.BedrockModel"))
-        stack.enter_context(patch("agents.art.specialized_agents.bedrock_session"))
+        stack.enter_context(patch("agents.art.specialized_agents.create_model"))
         stack.enter_context(
             patch("tools.art.experiment_tools.aggregate_experiment_results")
         )


### PR DESCRIPTION
### Description
Adding Ollama support by abstracting model creation into a new `model_factory`. User can choose between Bedrock and Ollama as their model provider via configuration in `.env`.

Verified that chat works with both providers.

<img width="1908" height="1103" alt="image" src="https://github.com/user-attachments/assets/c4d35387-5b60-4aa9-b0ba-6f0d5d0d60b8" />

```
2026-04-16 00:08:34,380 - orchestrator.router - INFO - [fa35ebd4-d214-4595-a0a4-f0c9ab1e7ab3] - Default: page_context='data-explorer' -> agent='default'
2026-04-16 00:08:35,546 - httpx - INFO - [fa35ebd4-d214-4595-a0a4-f0c9ab1e7ab3] - HTTP Request: POST https://ollama.home.jzeng.me/api/chat "HTTP/1.1 200 OK"
2026-04-16 00:08:46,110 - server.ag_ui_event_processor - INFO - [fa35ebd4-d214-4595-a0a4-f0c9ab1e7ab3] - Completed AG-UI run: run_id=run-1776323314376-j0m4vlnzs, thread_id=thread-1776323311903-269ycbu1p, user_id=client_127.0.0.1, events=140, duration=11.73s
2026-04-16 00:08:46,110 - utils.activity_monitor - INFO - [fa35ebd4-d214-4595-a0a4-f0c9ab1e7ab3] - Activity summary.
2026-04-16 00:08:46,110 - server.run_manager - INFO - [fa35ebd4-d214-4595-a0a4-f0c9ab1e7ab3] - Unregistered run.
```
### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
