### PR TITLE
Add PPL reference skill and skills auto-discovery to default agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Added
+- PPL reference skill and skills auto-discovery for the default agent
 ### Fixed
 ### Removed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 dependencies = [
     "opensearch-py",
     "mcp",
-    "strands-agents[ollama,otel]",
+    "strands-agents[ollama,otel]>=1.30.0",
     "openinference-instrumentation-bedrock",
     "python-dotenv",
     "opensearch-mcp-server-py",

--- a/skills/ppl-reference/SKILL.md
+++ b/skills/ppl-reference/SKILL.md
@@ -1,0 +1,1279 @@
+---
+name: ppl-reference
+description: Comprehensive PPL (Piped Processing Language) reference for OpenSearch with command syntax, functions, and examples for observability queries.
+allowed-tools:
+  - Bash
+  - curl
+---
+
+# PPL Language Reference
+
+## Overview
+
+This is a comprehensive reference for the Piped Processing Language (PPL) used by OpenSearch. PPL queries follow a pipe-delimited syntax starting with `source=<index>` and chaining commands with `|`. This reference covers all commands, functions, API endpoints, and usage patterns needed to construct observability queries against trace and log indices.
+
+Grammar sourced from the `opensearch-project/sql` repository's `docs/user/ppl/` directory:
+https://github.com/opensearch-project/sql
+
+## Connection Defaults
+
+| Variable | Default | Description |
+|---|---|---|
+| `OPENSEARCH_ENDPOINT` | `https://localhost:9200` | OpenSearch base URL |
+| `OPENSEARCH_USER` | `admin` | OpenSearch username |
+| `OPENSEARCH_PASSWORD` | `admin` | OpenSearch password |
+
+## Field Name Escaping
+
+Field names containing dots must be enclosed in backticks to avoid parsing errors:
+
+```
+`attributes.gen_ai.operation.name`
+`attributes.gen_ai.usage.input_tokens`
+`status.code`
+`events.attributes.exception.type`
+`@timestamp`
+```
+
+This is critical for OTel attribute fields which use dotted naming conventions.
+
+## API Endpoints
+
+### Query Endpoint
+
+Execute a PPL query:
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | stats count() by serviceName"}'
+```
+
+Request body: `{"query": "<ppl_query>"}`
+
+### Explain Endpoint
+
+Retrieve the query execution plan (useful for debugging and profiling):
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl/_explain" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | where `status.code` = 2 | stats count() by serviceName"}'
+```
+
+---
+
+## Commands
+
+### Core Query Commands
+
+#### search / source
+
+Start a query by specifying the data source index pattern.
+
+**Syntax**: `search source=<index-pattern>` or `source=<index-pattern>`
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | head 10"}'
+```
+
+#### where
+
+Filter results based on a condition.
+
+**Syntax**: `where <condition>`
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | where `status.code` = 2 | head 10"}'
+```
+
+Supports: `=`, `!=`, `<`, `>`, `<=`, `>=`, `AND`, `OR`, `NOT`, `LIKE`, `IN`, `BETWEEN`, `IS NULL`, `IS NOT NULL`.
+
+#### fields
+
+Select specific fields to return.
+
+**Syntax**: `fields [+|-] <field-list>`
+
+Use `+` to include or `-` to exclude fields.
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | fields traceId, spanId, serviceName, durationInNanos | head 10"}'
+```
+
+#### stats
+
+Aggregate data using statistical functions.
+
+**Syntax**: `stats <aggregation>... [by <field-list>]`
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | stats count() as span_count, avg(durationInNanos) as avg_duration by serviceName"}'
+```
+
+Supports: `count()`, `sum()`, `avg()`, `max()`, `min()`, `var_samp()`, `var_pop()`, `stddev_samp()`, `stddev_pop()`, `distinct_count()`, `percentile()`, `earliest()`, `latest()`, `list()`, `values()`, `first()`, `last()`.
+
+#### sort
+
+Order results by one or more fields.
+
+**Syntax**: `sort [+|-] <field> [, ...]`
+
+Use `+` for ascending (default), `-` for descending.
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | sort - durationInNanos | head 10"}'
+```
+
+#### head
+
+Limit the number of results returned.
+
+**Syntax**: `head [N]` (default N=10)
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | head 5"}'
+```
+
+#### eval
+
+Compute new fields from expressions.
+
+**Syntax**: `eval <new-field> = <expression> [, ...]`
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | eval duration_ms = durationInNanos / 1000000 | fields traceId, serviceName, duration_ms | sort - duration_ms | head 10"}'
+```
+
+#### dedup
+
+Remove duplicate results based on field values.
+
+**Syntax**: `dedup [N] <field-list> [keepempty=<bool>] [consecutive=<bool>]`
+
+> **Caveat:** `dedup` may throw a ClassCastException on fields with mixed types (e.g., a field that contains both strings and numbers across documents). Ensure the dedup field has a consistent type.
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | dedup serviceName | fields serviceName"}'
+```
+
+#### rename
+
+Rename one or more fields.
+
+**Syntax**: `rename <old-field> AS <new-field> [, ...]`
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | rename serviceName as service, durationInNanos as duration | fields traceId, service, duration | head 10"}'
+```
+
+#### top
+
+Find the most frequent values for a field.
+
+**Syntax**: `top [N] <field> [by <group-field>]`
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | top 5 serviceName"}'
+```
+
+#### rare
+
+Find the least frequent values for a field.
+
+**Syntax**: `rare <field> [by <group-field>]`
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | rare `attributes.gen_ai.operation.name`"}'
+```
+
+#### table
+
+Display results in tabular format (alias for fields in some contexts).
+
+**Syntax**: `table <field-list>`
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | where `status.code` = 2 | table traceId, spanId, serviceName, name | head 10"}'
+```
+
+### Time-Series Commands
+
+#### timechart
+
+Aggregate data into time buckets for time-series visualization.
+
+**Syntax**: `timechart span=<interval> <aggregation>... [by <field>]`
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | timechart span=5m count() as span_count by serviceName"}'
+```
+
+Rate functions for timechart: `per_second()`, `per_minute()`, `per_hour()`, `per_day()` — compute rate of an aggregation per time unit.
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | timechart span=1h per_minute(count()) as spans_per_min by serviceName"}'
+```
+
+#### chart
+
+General charting command for aggregation over arbitrary fields.
+
+**Syntax**: `chart <aggregation>... by <field> [span(<field>, <interval>)]`
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | chart avg(durationInNanos) by serviceName"}'
+```
+
+#### bin
+
+Bucket numeric or date values into intervals.
+
+**Syntax**: `eval <new-field> = bin(<field>, <interval>)` or used within `stats ... by span(<field>, <interval>)`
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | stats count() by span(durationInNanos, 1000000000)"}'
+```
+
+#### trendline
+
+Calculate moving averages over sorted data.
+
+**Syntax**: `trendline [sort <field>] sma(<period>, <field>) [as <alias>]`
+
+SMA = Simple Moving Average.
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | trendline sort startTime sma(10, durationInNanos) as avg_duration | fields startTime, durationInNanos, avg_duration | head 50"}'
+```
+
+#### streamstats
+
+Compute running (cumulative) statistics over ordered results.
+
+**Syntax**: `streamstats <aggregation>... [by <field>]`
+
+> **Caveat:** `streamstats` processes all matching rows in memory. On large indices, this will fail with "insufficient resources" errors. Always add `| head N` before `streamstats` to limit data volume.
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | sort startTime | streamstats count() as running_count, sum(`attributes.gen_ai.usage.input_tokens`) as cumulative_tokens | fields startTime, running_count, cumulative_tokens | head 50"}'
+```
+
+#### eventstats
+
+Add aggregation results as new fields to each row without collapsing rows (unlike `stats`).
+
+**Syntax**: `eventstats <aggregation>... [by <field>]`
+
+> **Caveat:** `eventstats` processes all matching rows in memory. On large indices, this will fail with "insufficient resources" errors. Always add `| head N` before `eventstats` to limit data volume.
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | eventstats avg(durationInNanos) as avg_svc_duration by serviceName | eval deviation = durationInNanos - avg_svc_duration | fields traceId, serviceName, durationInNanos, avg_svc_duration, deviation | sort - deviation | head 20"}'
+```
+
+### Parse/Extract Commands
+
+#### parse
+
+Extract fields from text using a regular expression with named groups.
+
+**Syntax**: `parse <field> '<regex-with-named-groups>'`
+
+> **Caveat:** `parse` may silently drop extracted fields on some OpenSearch versions. If extracted fields are missing from results, use `grok` or `rex` as more reliable alternatives.
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=logs-otel-v1-* | parse body '\''(?P<level>\\w+): (?P<msg>.+)'\'' | fields level, msg | head 10"}'
+```
+
+#### grok
+
+Extract fields using Grok patterns (predefined regex patterns).
+
+**Syntax**: `grok <field> '<grok-pattern>'`
+
+> **Caveat:** `grok` processes all matching rows in memory. On large indices, this will fail with "insufficient resources" errors. Always add `| head N` before `grok` to limit data volume.
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=logs-otel-v1-* | grok body '\''%{LOGLEVEL:level} %{GREEDYDATA:message}'\'' | fields level, message | head 10"}'
+```
+
+#### rex
+
+Extract fields using named capture groups (similar to parse but with Splunk-compatible syntax).
+
+**Syntax**: `rex field=<field> '<regex-with-named-groups>'`
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=logs-otel-v1-* | rex field=body '\''(?<statuscode>\\d{3})'\'' | fields statuscode, body | head 10"}'
+```
+
+#### regex
+
+Filter results using a regular expression match on a field.
+
+**Syntax**: `<field> = regex '<pattern>'` (used within `where`)
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=logs-otel-v1-* | where body like '\''%error%'\'' | fields traceId, body, severityText | head 10"}'
+```
+
+#### patterns
+
+Auto-discover log patterns by clustering similar log messages.
+
+**Syntax**: `patterns <field> [pattern='<regex>'] [new_field=<name>]`
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=logs-otel-v1-* | patterns body | fields body, patterns_field | head 20"}'
+```
+
+#### spath
+
+Extract values from structured data (JSON, XML) using path expressions.
+
+**Syntax**: `spath input=<field> [path=<path>] [output=<field>]`
+
+> **Note:** Verify the target field exists in your index before using `spath`. Run `describe <index-pattern>` first to confirm the field name. The example below uses a representative field; adjust to match your actual schema.
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | where isnotnull(`attributes.gen_ai.tool.name`) | spath input=`attributes.gen_ai.tool.name` | head 10"}'
+```
+
+### Join/Lookup Commands
+
+#### join
+
+Join results from two indices.
+
+**Syntax**: `join left=<alias> right=<alias> ON <condition> <right-source>` or `join <right-source> on <field>`
+
+Types: `inner`, `left`, `right`, `cross`.
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | join left=s right=l ON s.traceId = l.traceId logs-otel-v1-* | fields s.spanId, s.name, l.severityText, l.body | head 10"}'
+```
+
+#### lookup
+
+Enrich results by looking up values from another index.
+
+**Syntax**: `lookup <lookup-index> <match-field> [AS <alias>] [OUTPUT <field-list>]`
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | lookup otel-v2-apm-service-map serviceName AS `sourceNode` | fields serviceName, `targetNode`, durationInNanos | head 10"}'
+```
+
+> **Note:** The service map index (`otel-v2-apm-service-map`) uses nested fields `sourceNode` and `targetNode`, not `serviceName`. Match accordingly when joining or looking up against this index.
+
+#### graphlookup
+
+Perform graph traversal lookups for hierarchical or connected data.
+
+**Syntax**: `graphlookup <index> connectFromField=<field> connectToField=<field> [maxDepth=<N>] [as <alias>]`
+
+> **Caveat:** `graphlookup` has limited support in OpenSearch 3.x PPL and may not work as expected. Test carefully against your OpenSearch version before relying on this command in production queries.
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v2-apm-service-map | graphlookup otel-v2-apm-service-map connectFromField=`destination.domain` connectToField=serviceName maxDepth=3 as dependencies | head 10"}'
+```
+
+#### subquery
+
+Use a nested query as a data source or filter.
+
+**Syntax**: `where <field> IN [ source=<index> | ... | fields <field> ]`
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | where traceId IN [ source=otel-v1-apm-span-* | where `status.code` = 2 | fields traceId ] | fields traceId, spanId, serviceName, name | head 20"}'
+```
+
+#### append
+
+Append results from another query to the current result set.
+
+**Syntax**: `append [ source=<index> | ... ]`
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | stats count() as cnt by serviceName | append [ source=logs-otel-v1-* | stats count() as cnt by `resource.attributes.service.name` ] | head 20"}'
+```
+
+#### appendcol
+
+Append columns from another query to the current result set.
+
+**Syntax**: `appendcol [ <commands> ]`
+
+> **Caveat:** `source=` is not valid inside `appendcol []` subqueries. The subquery inside `appendcol` operates on the current result set, not a new index. Use `append` followed by reshaping if you need to bring in data from another index.
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | stats count() as span_count | appendcol [ source=logs-otel-v1-* | stats count() as log_count ]"}'
+```
+
+#### appendpipe
+
+Append the results of a sub-pipeline to the current results.
+
+**Syntax**: `appendpipe [ <commands> ]`
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | stats count() as cnt by serviceName | appendpipe [ stats sum(cnt) as total ]"}'
+```
+
+### Transform Commands
+
+#### fillnull
+
+Replace null values with a specified value.
+
+**Syntax**: `fillnull [with <value>] [<field-list>]`
+
+> **Caveat:** Backtick-quoted field names are not supported in the `fillnull` field list. Use `eval` to rename dotted fields to simple names before applying `fillnull`, or apply `fillnull` without a field list to fill all null fields.
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | fillnull with 0 `attributes.gen_ai.usage.input_tokens`, `attributes.gen_ai.usage.output_tokens` | fields traceId, `attributes.gen_ai.usage.input_tokens`, `attributes.gen_ai.usage.output_tokens` | head 10"}'
+```
+
+#### flatten
+
+Flatten nested fields into top-level fields.
+
+**Syntax**: `flatten <field>`
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | flatten events | head 10"}'
+```
+
+#### expand
+
+Expand multi-value or array fields into separate rows.
+
+**Syntax**: `expand <field>`
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | expand events | fields traceId, spanId, events | head 20"}'
+```
+
+#### transpose
+
+Pivot rows into columns.
+
+**Syntax**: `transpose [<N>] [include_null=<bool>]`
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | stats count() as cnt by serviceName | transpose"}'
+```
+
+#### convert
+
+Convert field types (e.g., string to number).
+
+**Syntax**: `convert <function>(<field>) [as <alias>]`
+
+Functions: `auto()`, `num()`, `ip()`, `ctime()`, `dur2sec()`, `mktime()`, `mstime()`, `rmcomma()`, `rmunit()`, `memk()`, `none()`.
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | eval duration_str = CAST(durationInNanos AS STRING) | convert num(duration_str) as duration_num | fields traceId, duration_num | head 10"}'
+```
+
+#### replace
+
+Replace values in a field using the `replace()` string function inside `eval`.
+
+**Syntax**: `eval <field> = replace(<field>, '<old>', '<new>')`
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=logs-otel-v1-* | eval severityText = replace(severityText, '\''ERROR'\'', '\''ERR'\'') | fields severityText, body | head 10"}'
+```
+
+#### reverse
+
+Reverse the order of results.
+
+**Syntax**: `reverse`
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | sort startTime | head 20 | reverse"}'
+```
+
+### Multi-Value Commands
+
+#### mvexpand
+
+Expand a multi-value field into separate rows (one row per value).
+
+**Syntax**: `mvexpand <field>`
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | mvexpand events | fields traceId, spanId, events | head 20"}'
+```
+
+#### mvcombine
+
+Combine multiple rows with the same key into a single row with a multi-value field.
+
+**Syntax**: `mvcombine <field>`
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | fields traceId, serviceName | mvcombine serviceName | head 10"}'
+```
+
+#### nomv
+
+Convert a multi-value field to a single-value field (takes the first value or joins with a delimiter).
+
+**Syntax**: `nomv <field>`
+
+> **Caveat:** `nomv` only works on string arrays, not nested object arrays. If the field contains nested objects (e.g., `events` with sub-fields), `nomv` will fail or produce unexpected results. Use `flatten` or `expand` for nested object arrays instead.
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | nomv events | fields traceId, events | head 10"}'
+```
+
+### Aggregation/Totals Commands
+
+#### addcoltotals
+
+Add a summary row at the bottom with column totals.
+
+**Syntax**: `addcoltotals [<field-list>]`
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | stats count() as cnt by serviceName | addcoltotals"}'
+```
+
+#### addtotals
+
+Add a new field to each row containing the sum of specified numeric fields.
+
+**Syntax**: `addtotals [row=<bool>] [col=<bool>] [<field-list>]`
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | stats sum(`attributes.gen_ai.usage.input_tokens`) as input_tok, sum(`attributes.gen_ai.usage.output_tokens`) as output_tok by serviceName | addtotals"}'
+```
+
+### ML Commands
+
+#### ad
+
+Anomaly detection — identify anomalous values in numeric fields using built-in ML algorithms.
+
+**Syntax**: `ad [time_field=<field>] [number_of_trees=<N>] [shingle_size=<N>] [time_zone=<tz>]`
+
+> **Note:** The `ad` command does not take a positional field argument. It auto-detects the input field(s) from the preceding `stats` or `eval` output in the pipeline.
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | where durationInNanos > 0 | ad time_field=startTime number_of_trees=100 time_zone=\"UTC\" | head 50"}'
+```
+
+#### kmeans
+
+Cluster data points using the k-means algorithm.
+
+**Syntax**: `kmeans [centroids=<N>] [iterations=<N>] [distance_type=<type>]`
+
+> **Note:** The `kmeans` command does not take positional field arguments. It operates on all numeric fields from the preceding pipeline output. Use `fields` or `eval` before `kmeans` to control which numeric fields are used for clustering.
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | where durationInNanos > 0 | fields traceId, serviceName, durationInNanos | kmeans centroids=3 | fields traceId, serviceName, durationInNanos, ClusterID | head 30"}'
+```
+
+#### ml
+
+General ML command for running machine learning algorithms on query results.
+
+**Syntax**: `ml action=<algorithm> [parameters...]`
+
+Supported algorithms include: `kmeans`, `ad` (anomaly detection).
+
+> **Note:** `ml action=rcf` is not a valid action in OpenSearch 3.x PPL. Random Cut Forest anomaly detection is accessed via the `ad` command directly (see the `ad` section above), not through `ml action=rcf`.
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | where durationInNanos > 0 | ml action=kmeans centroids=3 | head 50"}'
+```
+
+### System Commands
+
+#### describe
+
+Inspect the index mapping and field types for an index.
+
+**Syntax**: `describe <index-pattern>`
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "describe otel-v1-apm-span-*"}'
+```
+
+#### explain
+
+Show the query execution plan (used via the `_explain` API endpoint rather than as an inline command).
+
+**Syntax**: Use the `/_plugins/_ppl/_explain` endpoint with the query body.
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl/_explain" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | where `status.code` = 2 | stats count() by serviceName"}'
+```
+
+#### showdatasources
+
+List all configured data sources available for PPL queries.
+
+**Syntax**: `show datasources`
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "show datasources"}'
+```
+
+#### multisearch
+
+Execute multiple PPL queries in a single request. Each query is independent.
+
+**Syntax**: Use the `/_plugins/_ppl` endpoint with multiple queries separated by newlines (NDJSON format), or execute sequentially.
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | stats count() as total_spans"}'
+```
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=logs-otel-v1-* | stats count() as total_logs"}'
+```
+
+### Display Commands
+
+#### fieldformat
+
+Format the display of a field's values without changing the underlying data.
+
+**Syntax**: `fieldformat <field> = <format-expression>`
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | eval duration_ms = durationInNanos / 1000000 | fieldformat duration_ms = CONCAT(CAST(duration_ms AS STRING), '\'' ms'\'') | fields traceId, serviceName, duration_ms | head 10"}'
+```
+
+---
+
+## Span Expression Syntax
+
+The `span()` function buckets numeric or datetime values into intervals. Used with `stats`, `timechart`, and `chart`.
+
+**Syntax**: `span(<field>, <interval>)`
+
+### Supported Time Units
+
+| Unit | Description | Example |
+|------|-------------|---------|
+| `ms` | Milliseconds | `span(startTime, 500ms)` |
+| `s` | Seconds | `span(startTime, 30s)` |
+| `m` | Minutes | `span(startTime, 5m)` |
+| `h` | Hours | `span(startTime, 1h)` |
+| `d` | Days | `span(startTime, 1d)` |
+| `w` | Weeks | `span(startTime, 1w)` |
+| `M` | Months | `span(startTime, 1M)` |
+| `q` | Quarters | `span(startTime, 1q)` |
+| `y` | Years | `span(startTime, 1y)` |
+
+### Numeric Spans
+
+For numeric fields, the interval is a plain number:
+
+```
+stats count() by span(durationInNanos, 1000000000)
+```
+
+### Example
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | stats count() as span_count, avg(durationInNanos) as avg_duration by span(startTime, 1h)"}'
+```
+
+## Timechart Rate Functions
+
+Rate functions normalize aggregation values to a per-time-unit rate within `timechart`:
+
+| Function | Description |
+|----------|-------------|
+| `per_second(<agg>)` | Aggregation value per second |
+| `per_minute(<agg>)` | Aggregation value per minute |
+| `per_hour(<agg>)` | Aggregation value per hour |
+| `per_day(<agg>)` | Aggregation value per day |
+
+### Example
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | timechart span=5m per_second(count()) as requests_per_sec"}'
+```
+
+---
+
+## Functions
+
+### Aggregation Functions
+
+Used with `stats`, `eventstats`, `streamstats`, `timechart`, and `chart` commands.
+
+| Function | Syntax | Description |
+|----------|--------|-------------|
+| `COUNT` | `count()` | Count of events |
+| `SUM` | `sum(field)` | Sum of numeric values |
+| `AVG` | `avg(field)` | Arithmetic mean |
+| `MAX` | `max(field)` | Maximum value |
+| `MIN` | `min(field)` | Minimum value |
+| `VAR_SAMP` | `var_samp(field)` | Sample variance |
+| `VAR_POP` | `var_pop(field)` | Population variance |
+| `STDDEV_SAMP` | `stddev_samp(field)` | Sample standard deviation |
+| `STDDEV_POP` | `stddev_pop(field)` | Population standard deviation |
+| `DISTINCT_COUNT` | `distinct_count(field)` | Count of distinct values |
+| `PERCENTILE` | `percentile(field, pct)` | Value at the given percentile |
+| `EARLIEST` | `earliest(field)` | Earliest (first chronological) value |
+| `LATEST` | `latest(field)` | Latest (most recent) value |
+| `LIST` | `list(field)` | All values as a list |
+| `VALUES` | `values(field)` | Distinct values as a list |
+| `FIRST` | `first(field)` | First value encountered |
+| `LAST` | `last(field)` | Last value encountered |
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | stats count() as total, avg(durationInNanos) as avg_ns, percentile(durationInNanos, 95) as p95_ns, distinct_count(serviceName) as services"}'
+```
+
+### Collection Functions
+
+Functions for working with multi-value fields and arrays.
+
+| Function | Syntax | Description |
+|----------|--------|-------------|
+| `ARRAY` | `array(val1, val2, ...)` | Create an array from values |
+| `SPLIT` | `split(field, delimiter)` | Split a string into an array |
+| `MVJOIN` | `mvjoin(field, delimiter)` | Join multi-value field into a string |
+| `MVCOUNT` | `mvcount(field)` | Count of values in a multi-value field |
+| `MVINDEX` | `mvindex(field, index)` | Get value at index from multi-value field |
+| `MVFIRST` | `mvfirst(field)` | First value of a multi-value field |
+| `MVLAST` | `mvlast(field)` | Last value of a multi-value field |
+| `MVAPPEND` | `mvappend(field1, field2)` | Append two multi-value fields |
+| `MVDEDUP` | `mvdedup(field)` | Remove duplicates from multi-value field |
+| `MVSORT` | `mvsort(field)` | Sort values in a multi-value field |
+| `MVZIP` | `mvzip(field1, field2, delim)` | Zip two multi-value fields together |
+| `MVRANGE` | `mvrange(start, end, step)` | Generate a range of numeric values |
+| `MVFILTER` | `mvfilter(expression)` | Filter values in a multi-value field |
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | eval tokens = array(`attributes.gen_ai.usage.input_tokens`, `attributes.gen_ai.usage.output_tokens`) | fields traceId, tokens | head 10"}'
+```
+
+### Condition Functions
+
+Functions for conditional logic and null handling.
+
+| Function | Syntax | Description |
+|----------|--------|-------------|
+| `ISNULL` | `isnull(field)` | Returns true if field is null |
+| `ISNOTNULL` | `isnotnull(field)` | Returns true if field is not null |
+| `IF` | `if(cond, true_val, false_val)` | Conditional expression |
+| `IFNULL` | `ifnull(field, default)` | Return default if field is null |
+| `NULLIF` | `nullif(val1, val2)` | Return null if val1 equals val2 |
+| `CASE` | `case(cond1, val1, cond2, val2, ..., else_val)` | Multi-branch conditional |
+| `COALESCE` | `coalesce(val1, val2, ...)` | First non-null value |
+| `LIKE` | `field LIKE 'pattern'` | Wildcard pattern match (`%` and `_`) |
+| `IN` | `field IN (val1, val2, ...)` | Check membership in a set |
+| `BETWEEN` | `field BETWEEN val1 AND val2` | Range check (inclusive) |
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | eval status_label = case(`status.code` = 0, '\''UNSET'\'', `status.code` = 1, '\''OK'\'', `status.code` = 2, '\''ERROR'\'') | stats count() by status_label"}'
+```
+
+### Conversion Functions
+
+Functions for type casting and conversion.
+
+| Function | Syntax | Description |
+|----------|--------|-------------|
+| `CAST` | `cast(field AS type)` | Cast to a specified type (STRING, INT, LONG, FLOAT, DOUBLE, BOOLEAN, DATE, TIMESTAMP) |
+| `TOSTRING` | `tostring(field)` | Convert to string |
+| `TONUMBER` | `tonumber(field)` | Convert to number |
+| `TOINT` | `toint(field)` | Convert to integer |
+| `TOLONG` | `tolong(field)` | Convert to long |
+| `TOFLOAT` | `tofloat(field)` | Convert to float |
+| `TODOUBLE` | `todouble(field)` | Convert to double |
+| `TOBOOLEAN` | `toboolean(field)` | Convert to boolean |
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | eval duration_ms = CAST(durationInNanos AS DOUBLE) / 1000000.0 | fields traceId, serviceName, duration_ms | sort - duration_ms | head 10"}'
+```
+
+### Cryptographic Functions
+
+Functions for computing hash digests.
+
+| Function | Syntax | Description |
+|----------|--------|-------------|
+| `MD5` | `md5(field)` | MD5 hash of the value |
+| `SHA1` | `sha1(field)` | SHA-1 hash of the value |
+| `SHA2` | `sha2(field, numBits)` | SHA-2 hash (numBits: 224, 256, 384, 512) |
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | eval trace_hash = md5(traceId) | fields traceId, trace_hash | head 5"}'
+```
+
+### Datetime Functions
+
+Functions for date and time manipulation.
+
+| Function | Syntax | Description |
+|----------|--------|-------------|
+| `NOW` | `now()` | Current timestamp |
+| `CURDATE` | `curdate()` | Current date |
+| `CURTIME` | `curtime()` | Current time |
+| `DATE_FORMAT` | `date_format(date, fmt)` | Format a date (`%Y-%m-%d %H:%i:%s`) |
+| `DATE_ADD` | `date_add(date, INTERVAL n unit)` | Add interval to date |
+| `DATE_SUB` | `date_sub(date, INTERVAL n unit)` | Subtract interval from date |
+| `DATEDIFF` | `datediff(date1, date2)` | Difference in days between two dates |
+| `DAY` | `day(date)` | Day of month (1–31) |
+| `MONTH` | `month(date)` | Month (1–12) |
+| `YEAR` | `year(date)` | Year |
+| `HOUR` | `hour(time)` | Hour (0–23) |
+| `MINUTE` | `minute(time)` | Minute (0–59) |
+| `SECOND` | `second(time)` | Second (0–59) |
+| `DAYOFWEEK` | `dayofweek(date)` | Day of week (1=Sun, 7=Sat) |
+| `DAYOFYEAR` | `dayofyear(date)` | Day of year (1–366) |
+| `WEEK` | `week(date)` | Week number of the year |
+| `UNIX_TIMESTAMP` | `unix_timestamp(date)` | Convert to Unix epoch seconds |
+| `FROM_UNIXTIME` | `from_unixtime(epoch)` | Convert Unix epoch to timestamp |
+| `TIMESTAMPADD` | `timestampadd(unit, n, ts)` | Add interval to timestamp |
+| `TIMESTAMPDIFF` | `timestampdiff(unit, ts1, ts2)` | Difference between timestamps in given unit |
+| `PERIOD_ADD` | `period_add(period, n)` | Add months to a period (YYMM/YYYYMM) |
+| `PERIOD_DIFF` | `period_diff(p1, p2)` | Difference in months between periods |
+| `MAKETIME` | `maketime(h, m, s)` | Create a time value |
+| `MAKEDATE` | `makedate(year, dayofyear)` | Create a date from year and day-of-year |
+| `ADDDATE` | `adddate(date, INTERVAL n unit)` | Alias for DATE_ADD |
+| `SUBDATE` | `subdate(date, INTERVAL n unit)` | Alias for DATE_SUB |
+| `SYSDATE` | `sysdate()` | Current date and time (evaluated at execution) |
+| `UTC_DATE` | `utc_date()` | Current UTC date |
+| `UTC_TIME` | `utc_time()` | Current UTC time |
+| `UTC_TIMESTAMP` | `utc_timestamp()` | Current UTC timestamp |
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | where startTime > DATE_SUB(NOW(), INTERVAL 1 HOUR) | stats count() as recent_spans by serviceName"}'
+```
+
+### Expressions
+
+Operators for arithmetic, comparison, and logical expressions used in `eval`, `where`, and other commands.
+
+#### Arithmetic Operators
+
+| Operator | Description | Example |
+|----------|-------------|---------|
+| `+` | Addition | `eval total = input_tokens + output_tokens` |
+| `-` | Subtraction | `eval gap = endTime - startTime` |
+| `*` | Multiplication | `eval cost = tokens * price_per_token` |
+| `/` | Division | `eval duration_ms = durationInNanos / 1000000` |
+
+#### Comparison Operators
+
+| Operator | Description |
+|----------|-------------|
+| `=` | Equal to |
+| `!=` or `<>` | Not equal to |
+| `<` | Less than |
+| `>` | Greater than |
+| `<=` | Less than or equal to |
+| `>=` | Greater than or equal to |
+
+#### Logical Operators
+
+| Operator | Description |
+|----------|-------------|
+| `AND` | Logical AND |
+| `OR` | Logical OR |
+| `NOT` | Logical NOT |
+| `XOR` | Logical exclusive OR |
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | eval duration_ms = durationInNanos / 1000000, total_tokens = `attributes.gen_ai.usage.input_tokens` + `attributes.gen_ai.usage.output_tokens` | where duration_ms > 1000 AND total_tokens > 0 | fields traceId, serviceName, duration_ms, total_tokens | head 10"}'
+```
+
+### IP Functions
+
+Functions for IP address operations.
+
+| Function | Syntax | Description |
+|----------|--------|-------------|
+| `CIDRMATCH` | `cidrmatch(ip_field, 'cidr')` | Check if IP is within a CIDR range |
+| `GEOIP` | `geoip(ip_field)` | Geo-locate an IP address (returns country, region, city, lat/lon) |
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | where isnotnull(`attributes.net.peer.ip`) | where cidrmatch(`attributes.net.peer.ip`, '\''10.0.0.0/8'\'') | fields traceId, `attributes.net.peer.ip`, serviceName | head 10"}'
+```
+
+### JSON Functions
+
+Functions for working with JSON data.
+
+| Function | Syntax | Description |
+|----------|--------|-------------|
+| `JSON_EXTRACT` | `json_extract(field, path)` | Extract value at JSON path |
+| `JSON_KEYS` | `json_keys(field)` | Get all keys from a JSON object |
+| `JSON_VALID` | `json_valid(field)` | Check if value is valid JSON |
+| `JSON_ARRAY` | `json_array(val1, val2, ...)` | Create a JSON array |
+| `JSON_OBJECT` | `json_object(key1, val1, ...)` | Create a JSON object |
+| `JSON_ARRAY_LENGTH` | `json_array_length(field)` | Length of a JSON array |
+| `JSON_EXTRACT_PATH_TEXT` | `json_extract_path_text(field, path)` | Extract value as text from JSON path |
+| `TO_JSON_STRING` | `to_json_string(field)` | Convert value to JSON string |
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | where json_valid(`attributes.gen_ai.tool.call.arguments`) | eval tool_args = json_extract(`attributes.gen_ai.tool.call.arguments`, '\''$'\'') | fields traceId, `attributes.gen_ai.tool.name`, tool_args | head 10"}'
+```
+
+### Math Functions
+
+Functions for mathematical operations.
+
+| Function | Syntax | Description |
+|----------|--------|-------------|
+| `ABS` | `abs(val)` | Absolute value |
+| `CEIL` | `ceil(val)` | Round up to nearest integer |
+| `FLOOR` | `floor(val)` | Round down to nearest integer |
+| `ROUND` | `round(val [, decimals])` | Round to N decimal places |
+| `SQRT` | `sqrt(val)` | Square root |
+| `POW` | `pow(base, exp)` | Exponentiation |
+| `MOD` | `mod(a, b)` | Modulo (remainder) |
+| `LOG` | `log(val)` | Natural logarithm |
+| `LOG2` | `log2(val)` | Base-2 logarithm |
+| `LOG10` | `log10(val)` | Base-10 logarithm |
+| `LN` | `ln(val)` | Natural logarithm (alias for LOG) |
+| `EXP` | `exp(val)` | e raised to the power of val |
+| `SIGN` | `sign(val)` | Sign of value (-1, 0, 1) |
+| `TRUNCATE` | `truncate(val, decimals)` | Truncate to N decimal places |
+| `PI` | `pi()` | Value of π |
+| `E` | `e()` | Value of Euler's number |
+| `RAND` | `rand([seed])` | Random float between 0 and 1 |
+| `ACOS` | `acos(val)` | Arc cosine |
+| `ASIN` | `asin(val)` | Arc sine |
+| `ATAN` | `atan(val)` | Arc tangent |
+| `ATAN2` | `atan2(y, x)` | Two-argument arc tangent |
+| `COS` | `cos(val)` | Cosine |
+| `SIN` | `sin(val)` | Sine |
+| `TAN` | `tan(val)` | Tangent |
+| `COT` | `cot(val)` | Cotangent |
+| `DEGREES` | `degrees(radians)` | Convert radians to degrees |
+| `RADIANS` | `radians(degrees)` | Convert degrees to radians |
+| `CONV` | `conv(val, from_base, to_base)` | Convert between number bases |
+| `CRC32` | `crc32(val)` | CRC-32 checksum |
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | eval duration_ms = round(durationInNanos / 1000000.0, 2) | where duration_ms > 0 | fields traceId, serviceName, duration_ms | sort - duration_ms | head 10"}'
+```
+
+### Relevance Functions
+
+Full-text search functions for relevance-based querying.
+
+| Function | Syntax | Description |
+|----------|--------|-------------|
+| `MATCH` | `match(field, query)` | Full-text match on a single field |
+| `MATCH_PHRASE` | `match_phrase(field, phrase)` | Exact phrase match |
+| `MATCH_BOOL_PREFIX` | `match_bool_prefix(field, query)` | Boolean prefix match |
+| `MATCH_PHRASE_PREFIX` | `match_phrase_prefix(field, prefix)` | Phrase prefix match |
+| `MULTI_MATCH` | `multi_match([field1, field2], query)` | Match across multiple fields |
+| `QUERY_STRING` | `query_string([field1, field2], query)` | Lucene query string syntax |
+| `SIMPLE_QUERY_STRING` | `simple_query_string([field1, field2], query)` | Simplified query string |
+| `HIGHLIGHT` | `highlight(field)` | Return highlighted matching fragments |
+| `SCORE` | `score(relevance_func)` | Return relevance score |
+| `SCOREQUERY` | `scorequery(relevance_func)` | Filter by relevance score |
+| `MATCH_QUERY` | `match_query(field, query)` | Alias for MATCH |
+| `WILDCARD_QUERY` | `wildcard_query(field, pattern)` | Wildcard pattern match (`*` and `?`) |
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=logs-otel-v1-* | where match(body, '\''timeout error'\'') | fields traceId, severityText, body | head 10"}'
+```
+
+### Statistical Functions
+
+Functions for computing statistical correlations and covariances.
+
+| Function | Syntax | Description |
+|----------|--------|-------------|
+| `COVAR_POP` | `covar_pop(field1, field2)` | Population covariance |
+| `COVAR_SAMP` | `covar_samp(field1, field2)` | Sample covariance |
+
+> **Note:** `corr()` is not a recognized stats aggregation function in OpenSearch 3.x PPL. To approximate Pearson correlation, use `eval` with manual calculation or compute covariance and standard deviations separately. The `covar_samp` and `covar_pop` functions are supported.
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | where `attributes.gen_ai.usage.input_tokens` > 0 | stats covar_samp(`attributes.gen_ai.usage.input_tokens`, durationInNanos) as token_duration_covar"}'
+```
+
+### String Functions
+
+Functions for string manipulation.
+
+| Function | Syntax | Description |
+|----------|--------|-------------|
+| `CONCAT` | `concat(str1, str2, ...)` | Concatenate strings |
+| `LENGTH` | `length(str)` | String length in bytes |
+| `LOWER` | `lower(str)` | Convert to lowercase |
+| `UPPER` | `upper(str)` | Convert to uppercase |
+| `TRIM` | `trim(str)` | Remove leading/trailing whitespace |
+| `LTRIM` | `ltrim(str)` | Remove leading whitespace |
+| `RTRIM` | `rtrim(str)` | Remove trailing whitespace |
+| `SUBSTRING` | `substring(str, start [, len])` | Extract substring |
+| `LEFT` | `left(str, len)` | Leftmost N characters |
+| `RIGHT` | `right(str, len)` | Rightmost N characters |
+| `REPLACE` | `replace(str, from, to)` | Replace occurrences |
+| `REVERSE` | `reverse(str)` | Reverse a string |
+| `LOCATE` | `locate(substr, str [, pos])` | Position of substring |
+| `POSITION` | `position(substr IN str)` | Position of substring |
+| `ASCII` | `ascii(str)` | ASCII code of first character |
+| `CHAR_LENGTH` | `char_length(str)` | Character count |
+| `CHARACTER_LENGTH` | `character_length(str)` | Alias for CHAR_LENGTH |
+| `OCTET_LENGTH` | `octet_length(str)` | Byte count |
+| `BIT_LENGTH` | `bit_length(str)` | Bit count |
+| `LPAD` | `lpad(str, len, pad)` | Left-pad to length |
+| `RPAD` | `rpad(str, len, pad)` | Right-pad to length |
+| `SPACE` | `space(n)` | String of N spaces |
+| `REPEAT` | `repeat(str, n)` | Repeat string N times |
+| `STRCMP` | `strcmp(str1, str2)` | Compare strings (-1, 0, 1) |
+| `SUBSTR` | `substr(str, start [, len])` | Alias for SUBSTRING |
+| `MID` | `mid(str, start, len)` | Alias for SUBSTRING |
+| `FIELD` | `field(str, val1, val2, ...)` | Index of str in value list |
+| `FIND_IN_SET` | `find_in_set(str, strlist)` | Position in comma-separated list |
+| `FORMAT` | `format(val, decimals)` | Format number with commas and decimals |
+| `INSERT` | `insert(str, pos, len, newstr)` | Insert string at position |
+| `INSTR` | `instr(str, substr)` | Position of first occurrence |
+| `REGEXP` | `regexp(str, pattern)` | Regex match (returns 1 or 0) |
+| `REGEXP_EXTRACT` | `regexp_extract(str, pattern [, group])` | Extract regex capture group |
+| `REGEXP_REPLACE` | `regexp_replace(str, pattern, replacement)` | Replace regex matches |
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=logs-otel-v1-* | eval body_lower = lower(body) | where body_lower like '\''%exception%'\'' | eval short_body = left(body, 200) | fields traceId, severityText, short_body | head 10"}'
+```
+
+### System Functions
+
+| Function | Syntax | Description |
+|----------|--------|-------------|
+| `TYPEOF` | `typeof(field)` | Returns the data type of a field value |
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | eval type_of_duration = typeof(durationInNanos) | fields traceId, durationInNanos, type_of_duration | head 5"}'
+```
+
+---
+
+## Grammar Source
+
+This PPL reference is sourced from the `opensearch-project/sql` repository's `docs/user/ppl/` directory.
+
+Repository: https://github.com/opensearch-project/sql
+
+The PPL grammar is maintained as part of the OpenSearch SQL plugin. For the latest syntax additions and changes, consult the repository documentation directly.
+
+## References
+
+- [PPL Language Reference](https://github.com/opensearch-project/sql/blob/main/docs/user/ppl/index.md) — Official PPL syntax documentation. Fetch this if queries fail due to OpenSearch version differences or new syntax.

--- a/skills/ppl-reference/SKILL.md
+++ b/skills/ppl-reference/SKILL.md
@@ -1,1279 +1,427 @@
 ---
 name: ppl-reference
 description: Comprehensive PPL (Piped Processing Language) reference for OpenSearch with command syntax, functions, and examples for observability queries.
-allowed-tools:
-  - Bash
-  - curl
 ---
 
 # PPL Language Reference
 
-## Overview
-
-This is a comprehensive reference for the Piped Processing Language (PPL) used by OpenSearch. PPL queries follow a pipe-delimited syntax starting with `source=<index>` and chaining commands with `|`. This reference covers all commands, functions, API endpoints, and usage patterns needed to construct observability queries against trace and log indices.
-
-Grammar sourced from the `opensearch-project/sql` repository's `docs/user/ppl/` directory:
-https://github.com/opensearch-project/sql
-
-## Connection Defaults
-
-| Variable | Default | Description |
-|---|---|---|
-| `OPENSEARCH_ENDPOINT` | `https://localhost:9200` | OpenSearch base URL |
-| `OPENSEARCH_USER` | `admin` | OpenSearch username |
-| `OPENSEARCH_PASSWORD` | `admin` | OpenSearch password |
+Piped Processing Language (PPL) for OpenSearch. Queries use pipe-delimited syntax starting with `source=<index>` and chaining commands with `|`. Grammar source: https://github.com/opensearch-project/sql
 
 ## Field Name Escaping
 
-Field names containing dots must be enclosed in backticks to avoid parsing errors:
+Field names containing dots, `@`, or other special characters must be enclosed in backticks:
 
 ```
-`attributes.gen_ai.operation.name`
-`attributes.gen_ai.usage.input_tokens`
-`status.code`
-`events.attributes.exception.type`
-`@timestamp`
+`status.code`, `attributes.gen_ai.usage.input_tokens`, `@timestamp`, `geo.src`
 ```
 
-This is critical for OTel attribute fields which use dotted naming conventions.
+Critical for OTel attribute fields which use dotted naming conventions.
 
 ## API Endpoints
 
-### Query Endpoint
-
-Execute a PPL query:
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | stats count() by serviceName"}'
 ```
+POST /_plugins/_ppl              # Execute query
+POST /_plugins/_ppl/_explain     # Get execution plan
 
-Request body: `{"query": "<ppl_query>"}`
-
-### Explain Endpoint
-
-Retrieve the query execution plan (useful for debugging and profiling):
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl/_explain" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | where `status.code` = 2 | stats count() by serviceName"}'
+Body: {"query": "<ppl_query>"}
 ```
 
 ---
 
 ## Commands
 
-### Core Query Commands
+### Core
 
-#### search / source
-
-Start a query by specifying the data source index pattern.
-
-**Syntax**: `search source=<index-pattern>` or `source=<index-pattern>`
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | head 10"}'
+**`source=<index-pattern>`** — Start a query. Alias: `search source=`.
+```
+source=otel-v1-apm-span-* | head 10
 ```
 
-#### where
-
-Filter results based on a condition.
-
-**Syntax**: `where <condition>`
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | where `status.code` = 2 | head 10"}'
+**`where <condition>`** — Filter results. Operators: `=`, `!=`, `<`, `>`, `<=`, `>=`, `AND`, `OR`, `NOT`, `LIKE`, `IN`, `BETWEEN`, `IS NULL`, `IS NOT NULL`.
+```
+source=otel-v1-apm-span-* | where `status.code` = 2
 ```
 
-Supports: `=`, `!=`, `<`, `>`, `<=`, `>=`, `AND`, `OR`, `NOT`, `LIKE`, `IN`, `BETWEEN`, `IS NULL`, `IS NOT NULL`.
-
-#### fields
-
-Select specific fields to return.
-
-**Syntax**: `fields [+|-] <field-list>`
-
-Use `+` to include or `-` to exclude fields.
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | fields traceId, spanId, serviceName, durationInNanos | head 10"}'
+**`fields [+|-] <field-list>`** — Select (`+`) or exclude (`-`) fields. Default is `+`.
+```
+source=otel-v1-apm-span-* | fields traceId, serviceName, durationInNanos
 ```
 
-#### stats
-
-Aggregate data using statistical functions.
-
-**Syntax**: `stats <aggregation>... [by <field-list>]`
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | stats count() as span_count, avg(durationInNanos) as avg_duration by serviceName"}'
+**`stats <aggregation>... [by <field-list>]`** — Aggregate. Functions: `count()`, `sum()`, `avg()`, `max()`, `min()`, `var_samp()`, `var_pop()`, `stddev_samp()`, `stddev_pop()`, `distinct_count()`, `percentile(field, pct)`, `earliest()`, `latest()`, `list()`, `values()`, `first()`, `last()`.
+```
+source=otel-v1-apm-span-* | stats count() as n, avg(durationInNanos) as avg_dur by serviceName
 ```
 
-Supports: `count()`, `sum()`, `avg()`, `max()`, `min()`, `var_samp()`, `var_pop()`, `stddev_samp()`, `stddev_pop()`, `distinct_count()`, `percentile()`, `earliest()`, `latest()`, `list()`, `values()`, `first()`, `last()`.
-
-#### sort
-
-Order results by one or more fields.
-
-**Syntax**: `sort [+|-] <field> [, ...]`
-
-Use `+` for ascending (default), `-` for descending.
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | sort - durationInNanos | head 10"}'
+**`sort [+|-] <field>`** — `+` ascending (default), `-` descending.
+```
+source=otel-v1-apm-span-* | sort - durationInNanos | head 10
 ```
 
-#### head
-
-Limit the number of results returned.
-
-**Syntax**: `head [N]` (default N=10)
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | head 5"}'
+**`head [N]`** — Limit (default N=10). **`reverse`** — Reverse order.
+```
+source=otel-v1-apm-span-* | head 5
 ```
 
-#### eval
-
-Compute new fields from expressions.
-
-**Syntax**: `eval <new-field> = <expression> [, ...]`
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | eval duration_ms = durationInNanos / 1000000 | fields traceId, serviceName, duration_ms | sort - duration_ms | head 10"}'
+**`eval <field> = <expression>`** — Compute new fields.
+```
+source=otel-v1-apm-span-* | eval duration_ms = durationInNanos / 1000000
 ```
 
-#### dedup
+**`dedup [N] <field-list> [keepempty=<bool>] [consecutive=<bool>]`** — Remove duplicates.
 
-Remove duplicate results based on field values.
+> **Caveat:** `dedup` may throw a ClassCastException on fields with mixed types. Ensure consistent type.
 
-**Syntax**: `dedup [N] <field-list> [keepempty=<bool>] [consecutive=<bool>]`
-
-> **Caveat:** `dedup` may throw a ClassCastException on fields with mixed types (e.g., a field that contains both strings and numbers across documents). Ensure the dedup field has a consistent type.
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | dedup serviceName | fields serviceName"}'
+```
+source=otel-v1-apm-span-* | dedup serviceName
 ```
 
-#### rename
-
-Rename one or more fields.
-
-**Syntax**: `rename <old-field> AS <new-field> [, ...]`
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | rename serviceName as service, durationInNanos as duration | fields traceId, service, duration | head 10"}'
+**`rename <old> AS <new>`** — Rename fields.
+```
+source=otel-v1-apm-span-* | rename serviceName as service, durationInNanos as duration
 ```
 
-#### top
-
-Find the most frequent values for a field.
-
-**Syntax**: `top [N] <field> [by <group-field>]`
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | top 5 serviceName"}'
+**`top [N] <field> [by <group>]`** / **`rare <field> [by <group>]`** — Most/least frequent values.
+```
+source=otel-v1-apm-span-* | top 5 serviceName
 ```
 
-#### rare
+**`table <field-list>`** — Tabular display (alias for `fields` in some contexts).
 
-Find the least frequent values for a field.
+### Time-Series
 
-**Syntax**: `rare <field> [by <group-field>]`
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | rare `attributes.gen_ai.operation.name`"}'
+**`timechart span=<interval> <aggregation>... [by <field>]`** — Time-bucketed aggregation. Rate functions: `per_second()`, `per_minute()`, `per_hour()`, `per_day()`.
+```
+source=otel-v1-apm-span-* | timechart span=5m count() as n by serviceName
+source=otel-v1-apm-span-* | timechart span=1h per_minute(count()) as spans_per_min
 ```
 
-#### table
-
-Display results in tabular format (alias for fields in some contexts).
-
-**Syntax**: `table <field-list>`
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | where `status.code` = 2 | table traceId, spanId, serviceName, name | head 10"}'
+**`chart <aggregation>... by <field>`** — General charting.
+```
+source=otel-v1-apm-span-* | chart avg(durationInNanos) by serviceName
 ```
 
-### Time-Series Commands
-
-#### timechart
-
-Aggregate data into time buckets for time-series visualization.
-
-**Syntax**: `timechart span=<interval> <aggregation>... [by <field>]`
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | timechart span=5m count() as span_count by serviceName"}'
+**`bin`** / **`span(<field>, <interval>)`** — Bucket values. See Span Expression section below.
+```
+source=otel-v1-apm-span-* | stats count() by span(durationInNanos, 1000000000)
 ```
 
-Rate functions for timechart: `per_second()`, `per_minute()`, `per_hour()`, `per_day()` — compute rate of an aggregation per time unit.
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | timechart span=1h per_minute(count()) as spans_per_min by serviceName"}'
+**`trendline [sort <field>] sma(<period>, <field>) [as <alias>]`** — Simple moving average.
+```
+source=otel-v1-apm-span-* | trendline sort startTime sma(10, durationInNanos) as avg_duration
 ```
 
-#### chart
+**`streamstats <aggregation>... [by <field>]`** — Running cumulative stats.
 
-General charting command for aggregation over arbitrary fields.
+> **Caveat:** Processes all rows in memory. Always add `| head N` before `streamstats` to limit data volume.
 
-**Syntax**: `chart <aggregation>... by <field> [span(<field>, <interval>)]`
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | chart avg(durationInNanos) by serviceName"}'
+```
+source=otel-v1-apm-span-* | sort startTime | head 50 | streamstats count() as running_count
 ```
 
-#### bin
+**`eventstats <aggregation>... [by <field>]`** — Add aggregation as new field without collapsing rows.
 
-Bucket numeric or date values into intervals.
+> **Caveat:** Processes all rows in memory. Always add `| head N` before `eventstats`.
 
-**Syntax**: `eval <new-field> = bin(<field>, <interval>)` or used within `stats ... by span(<field>, <interval>)`
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | stats count() by span(durationInNanos, 1000000000)"}'
+```
+source=otel-v1-apm-span-* | head 100 | eventstats avg(durationInNanos) as avg_svc by serviceName | eval deviation = durationInNanos - avg_svc
 ```
 
-#### trendline
+### Parse / Extract
 
-Calculate moving averages over sorted data.
+**`parse <field> '<regex-with-named-groups>'`** — Extract fields via regex.
 
-**Syntax**: `trendline [sort <field>] sma(<period>, <field>) [as <alias>]`
+> **Caveat:** May silently drop extracted fields on some OpenSearch versions. Use `grok` or `rex` if `parse` misbehaves.
 
-SMA = Simple Moving Average.
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | trendline sort startTime sma(10, durationInNanos) as avg_duration | fields startTime, durationInNanos, avg_duration | head 50"}'
+```
+source=logs-otel-v1-* | parse body '(?P<level>\w+): (?P<msg>.+)'
 ```
 
-#### streamstats
+**`grok <field> '<grok-pattern>'`** — Extract via named Grok patterns.
 
-Compute running (cumulative) statistics over ordered results.
+> **Caveat:** Processes all rows in memory. Always add `| head N` before `grok`.
 
-**Syntax**: `streamstats <aggregation>... [by <field>]`
-
-> **Caveat:** `streamstats` processes all matching rows in memory. On large indices, this will fail with "insufficient resources" errors. Always add `| head N` before `streamstats` to limit data volume.
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | sort startTime | streamstats count() as running_count, sum(`attributes.gen_ai.usage.input_tokens`) as cumulative_tokens | fields startTime, running_count, cumulative_tokens | head 50"}'
+```
+source=logs-otel-v1-* | head 100 | grok body '%{LOGLEVEL:level} %{GREEDYDATA:message}'
 ```
 
-#### eventstats
-
-Add aggregation results as new fields to each row without collapsing rows (unlike `stats`).
-
-**Syntax**: `eventstats <aggregation>... [by <field>]`
-
-> **Caveat:** `eventstats` processes all matching rows in memory. On large indices, this will fail with "insufficient resources" errors. Always add `| head N` before `eventstats` to limit data volume.
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | eventstats avg(durationInNanos) as avg_svc_duration by serviceName | eval deviation = durationInNanos - avg_svc_duration | fields traceId, serviceName, durationInNanos, avg_svc_duration, deviation | sort - deviation | head 20"}'
+**`rex field=<field> '<regex>'`** — Splunk-compatible regex extract.
+```
+source=logs-otel-v1-* | rex field=body '(?<statuscode>\d{3})'
 ```
 
-### Parse/Extract Commands
-
-#### parse
-
-Extract fields from text using a regular expression with named groups.
-
-**Syntax**: `parse <field> '<regex-with-named-groups>'`
-
-> **Caveat:** `parse` may silently drop extracted fields on some OpenSearch versions. If extracted fields are missing from results, use `grok` or `rex` as more reliable alternatives.
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=logs-otel-v1-* | parse body '\''(?P<level>\\w+): (?P<msg>.+)'\'' | fields level, msg | head 10"}'
+**`patterns <field>`** — Auto-cluster similar log messages.
+```
+source=logs-otel-v1-* | patterns body
 ```
 
-#### grok
+**`spath input=<field> [path=<path>] [output=<field>]`** — Extract from structured data (JSON/XML).
 
-Extract fields using Grok patterns (predefined regex patterns).
+> **Note:** Verify the target field exists (`describe <index>`) before using `spath`.
 
-**Syntax**: `grok <field> '<grok-pattern>'`
-
-> **Caveat:** `grok` processes all matching rows in memory. On large indices, this will fail with "insufficient resources" errors. Always add `| head N` before `grok` to limit data volume.
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=logs-otel-v1-* | grok body '\''%{LOGLEVEL:level} %{GREEDYDATA:message}'\'' | fields level, message | head 10"}'
+```
+source=otel-v1-apm-span-* | where isnotnull(`attributes.gen_ai.tool.name`) | spath input=`attributes.gen_ai.tool.name`
 ```
 
-#### rex
+### Join / Lookup / Subquery
 
-Extract fields using named capture groups (similar to parse but with Splunk-compatible syntax).
-
-**Syntax**: `rex field=<field> '<regex-with-named-groups>'`
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=logs-otel-v1-* | rex field=body '\''(?<statuscode>\\d{3})'\'' | fields statuscode, body | head 10"}'
+**`join left=<alias> right=<alias> ON <condition> <right-source>`** — Types: `inner`, `left`, `right`, `cross`.
+```
+source=otel-v1-apm-span-* | join left=s right=l ON s.traceId = l.traceId logs-otel-v1-*
 ```
 
-#### regex
+**`lookup <lookup-index> <match-field> [AS <alias>] [OUTPUT <field-list>]`** — Enrich from another index.
 
-Filter results using a regular expression match on a field.
+> **Note:** The service map index (`otel-v2-apm-service-map`) uses `sourceNode`/`targetNode`, not `serviceName`.
 
-**Syntax**: `<field> = regex '<pattern>'` (used within `where`)
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=logs-otel-v1-* | where body like '\''%error%'\'' | fields traceId, body, severityText | head 10"}'
+```
+source=otel-v1-apm-span-* | lookup otel-v2-apm-service-map serviceName AS `sourceNode`
 ```
 
-#### patterns
+**`graphlookup <index> connectFromField=<f> connectToField=<f> [maxDepth=<N>]`** — Graph traversal.
 
-Auto-discover log patterns by clustering similar log messages.
+> **Caveat:** Limited support in OpenSearch 3.x PPL. Test before relying on this.
 
-**Syntax**: `patterns <field> [pattern='<regex>'] [new_field=<name>]`
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=logs-otel-v1-* | patterns body | fields body, patterns_field | head 20"}'
+**`where <field> IN [ source=<index> | ... | fields <field> ]`** — Subquery filter.
+```
+source=otel-v1-apm-span-* | where traceId IN [ source=otel-v1-apm-span-* | where `status.code` = 2 | fields traceId ]
 ```
 
-#### spath
-
-Extract values from structured data (JSON, XML) using path expressions.
-
-**Syntax**: `spath input=<field> [path=<path>] [output=<field>]`
-
-> **Note:** Verify the target field exists in your index before using `spath`. Run `describe <index-pattern>` first to confirm the field name. The example below uses a representative field; adjust to match your actual schema.
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | where isnotnull(`attributes.gen_ai.tool.name`) | spath input=`attributes.gen_ai.tool.name` | head 10"}'
+**`append [ source=<index> | ... ]`** — Append rows from another query.
+```
+source=otel-v1-apm-span-* | stats count() as cnt by serviceName | append [ source=logs-otel-v1-* | stats count() as cnt by `resource.attributes.service.name` ]
 ```
 
-### Join/Lookup Commands
+**`appendcol [ <commands> ]`** — Append columns from a sub-pipeline.
 
-#### join
+> **Caveat:** `source=` is NOT valid inside `appendcol[]` — it operates on the current result set. Use `append` if you need data from another index.
 
-Join results from two indices.
-
-**Syntax**: `join left=<alias> right=<alias> ON <condition> <right-source>` or `join <right-source> on <field>`
-
-Types: `inner`, `left`, `right`, `cross`.
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | join left=s right=l ON s.traceId = l.traceId logs-otel-v1-* | fields s.spanId, s.name, l.severityText, l.body | head 10"}'
+**`appendpipe [ <commands> ]`** — Append results of sub-pipeline on current data.
+```
+source=otel-v1-apm-span-* | stats count() as cnt by serviceName | appendpipe [ stats sum(cnt) as total ]
 ```
 
-#### lookup
+### Transform
 
-Enrich results by looking up values from another index.
+**`fillnull [with <value>] [<field-list>]`** — Replace nulls.
 
-**Syntax**: `lookup <lookup-index> <match-field> [AS <alias>] [OUTPUT <field-list>]`
+> **Caveat:** Backtick-quoted field names are NOT supported in `fillnull` field list. Use `eval` to rename dotted fields first, or apply without a field list.
 
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | lookup otel-v2-apm-service-map serviceName AS `sourceNode` | fields serviceName, `targetNode`, durationInNanos | head 10"}'
+```
+source=otel-v1-apm-span-* | eval tokens = `attributes.gen_ai.usage.input_tokens` | fillnull with 0 tokens
 ```
 
-> **Note:** The service map index (`otel-v2-apm-service-map`) uses nested fields `sourceNode` and `targetNode`, not `serviceName`. Match accordingly when joining or looking up against this index.
+**`flatten <field>`** — Flatten nested fields to top level.
+**`expand <field>`** / **`mvexpand <field>`** — Expand array/multi-value fields into separate rows.
+**`transpose [<N>]`** — Pivot rows into columns.
+**`mvcombine <field>`** — Combine rows with same key into multi-value field.
 
-#### graphlookup
+**`nomv <field>`** — Multi-value → single-value.
 
-Perform graph traversal lookups for hierarchical or connected data.
+> **Caveat:** Only works on string arrays. Use `flatten` or `expand` for nested object arrays.
 
-**Syntax**: `graphlookup <index> connectFromField=<field> connectToField=<field> [maxDepth=<N>] [as <alias>]`
+**`convert <function>(<field>) [as <alias>]`** — Type conversion. Functions: `auto()`, `num()`, `ip()`, `ctime()`, `dur2sec()`, `mktime()`, `mstime()`, `rmcomma()`, `rmunit()`, `memk()`, `none()`.
 
-> **Caveat:** `graphlookup` has limited support in OpenSearch 3.x PPL and may not work as expected. Test carefully against your OpenSearch version before relying on this command in production queries.
+**`eval <field> = replace(<field>, '<old>', '<new>')`** — Replace values via `replace()` string function.
 
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v2-apm-service-map | graphlookup otel-v2-apm-service-map connectFromField=`destination.domain` connectToField=serviceName maxDepth=3 as dependencies | head 10"}'
+### Totals
+
+**`addcoltotals [<field-list>]`** — Add summary row with column totals.
+**`addtotals [row=<bool>] [col=<bool>] [<field-list>]`** — Add row with sum of numeric fields.
+```
+source=otel-v1-apm-span-* | stats count() as cnt by serviceName | addcoltotals
 ```
 
-#### subquery
+### ML
 
-Use a nested query as a data source or filter.
+**`ad [time_field=<field>] [number_of_trees=<N>] [shingle_size=<N>] [time_zone=<tz>]`** — Anomaly detection.
 
-**Syntax**: `where <field> IN [ source=<index> | ... | fields <field> ]`
+> **Note:** `ad` takes no positional field argument; it auto-detects from preceding `stats`/`eval` output.
 
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | where traceId IN [ source=otel-v1-apm-span-* | where `status.code` = 2 | fields traceId ] | fields traceId, spanId, serviceName, name | head 20"}'
+```
+source=otel-v1-apm-span-* | where durationInNanos > 0 | ad time_field=startTime number_of_trees=100
 ```
 
-#### append
+**`kmeans [centroids=<N>] [iterations=<N>] [distance_type=<type>]`** — K-means clustering.
 
-Append results from another query to the current result set.
+> **Note:** No positional field args; operates on all numeric fields from preceding output. Use `fields` to control input.
 
-**Syntax**: `append [ source=<index> | ... ]`
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | stats count() as cnt by serviceName | append [ source=logs-otel-v1-* | stats count() as cnt by `resource.attributes.service.name` ] | head 20"}'
+```
+source=otel-v1-apm-span-* | fields durationInNanos | kmeans centroids=3
 ```
 
-#### appendcol
+**`ml action=<algorithm>`** — General ML command. Supported: `kmeans`, `ad`.
 
-Append columns from another query to the current result set.
-
-**Syntax**: `appendcol [ <commands> ]`
-
-> **Caveat:** `source=` is not valid inside `appendcol []` subqueries. The subquery inside `appendcol` operates on the current result set, not a new index. Use `append` followed by reshaping if you need to bring in data from another index.
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | stats count() as span_count | appendcol [ source=logs-otel-v1-* | stats count() as log_count ]"}'
-```
-
-#### appendpipe
-
-Append the results of a sub-pipeline to the current results.
-
-**Syntax**: `appendpipe [ <commands> ]`
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | stats count() as cnt by serviceName | appendpipe [ stats sum(cnt) as total ]"}'
-```
-
-### Transform Commands
-
-#### fillnull
-
-Replace null values with a specified value.
-
-**Syntax**: `fillnull [with <value>] [<field-list>]`
-
-> **Caveat:** Backtick-quoted field names are not supported in the `fillnull` field list. Use `eval` to rename dotted fields to simple names before applying `fillnull`, or apply `fillnull` without a field list to fill all null fields.
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | fillnull with 0 `attributes.gen_ai.usage.input_tokens`, `attributes.gen_ai.usage.output_tokens` | fields traceId, `attributes.gen_ai.usage.input_tokens`, `attributes.gen_ai.usage.output_tokens` | head 10"}'
-```
-
-#### flatten
-
-Flatten nested fields into top-level fields.
-
-**Syntax**: `flatten <field>`
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | flatten events | head 10"}'
-```
-
-#### expand
-
-Expand multi-value or array fields into separate rows.
-
-**Syntax**: `expand <field>`
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | expand events | fields traceId, spanId, events | head 20"}'
-```
-
-#### transpose
-
-Pivot rows into columns.
-
-**Syntax**: `transpose [<N>] [include_null=<bool>]`
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | stats count() as cnt by serviceName | transpose"}'
-```
-
-#### convert
-
-Convert field types (e.g., string to number).
-
-**Syntax**: `convert <function>(<field>) [as <alias>]`
-
-Functions: `auto()`, `num()`, `ip()`, `ctime()`, `dur2sec()`, `mktime()`, `mstime()`, `rmcomma()`, `rmunit()`, `memk()`, `none()`.
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | eval duration_str = CAST(durationInNanos AS STRING) | convert num(duration_str) as duration_num | fields traceId, duration_num | head 10"}'
-```
-
-#### replace
-
-Replace values in a field using the `replace()` string function inside `eval`.
-
-**Syntax**: `eval <field> = replace(<field>, '<old>', '<new>')`
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=logs-otel-v1-* | eval severityText = replace(severityText, '\''ERROR'\'', '\''ERR'\'') | fields severityText, body | head 10"}'
-```
-
-#### reverse
-
-Reverse the order of results.
-
-**Syntax**: `reverse`
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | sort startTime | head 20 | reverse"}'
-```
-
-### Multi-Value Commands
-
-#### mvexpand
-
-Expand a multi-value field into separate rows (one row per value).
-
-**Syntax**: `mvexpand <field>`
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | mvexpand events | fields traceId, spanId, events | head 20"}'
-```
-
-#### mvcombine
-
-Combine multiple rows with the same key into a single row with a multi-value field.
-
-**Syntax**: `mvcombine <field>`
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | fields traceId, serviceName | mvcombine serviceName | head 10"}'
-```
-
-#### nomv
-
-Convert a multi-value field to a single-value field (takes the first value or joins with a delimiter).
-
-**Syntax**: `nomv <field>`
-
-> **Caveat:** `nomv` only works on string arrays, not nested object arrays. If the field contains nested objects (e.g., `events` with sub-fields), `nomv` will fail or produce unexpected results. Use `flatten` or `expand` for nested object arrays instead.
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | nomv events | fields traceId, events | head 10"}'
-```
-
-### Aggregation/Totals Commands
-
-#### addcoltotals
-
-Add a summary row at the bottom with column totals.
-
-**Syntax**: `addcoltotals [<field-list>]`
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | stats count() as cnt by serviceName | addcoltotals"}'
-```
-
-#### addtotals
-
-Add a new field to each row containing the sum of specified numeric fields.
-
-**Syntax**: `addtotals [row=<bool>] [col=<bool>] [<field-list>]`
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | stats sum(`attributes.gen_ai.usage.input_tokens`) as input_tok, sum(`attributes.gen_ai.usage.output_tokens`) as output_tok by serviceName | addtotals"}'
-```
-
-### ML Commands
-
-#### ad
-
-Anomaly detection — identify anomalous values in numeric fields using built-in ML algorithms.
-
-**Syntax**: `ad [time_field=<field>] [number_of_trees=<N>] [shingle_size=<N>] [time_zone=<tz>]`
-
-> **Note:** The `ad` command does not take a positional field argument. It auto-detects the input field(s) from the preceding `stats` or `eval` output in the pipeline.
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | where durationInNanos > 0 | ad time_field=startTime number_of_trees=100 time_zone=\"UTC\" | head 50"}'
-```
-
-#### kmeans
-
-Cluster data points using the k-means algorithm.
-
-**Syntax**: `kmeans [centroids=<N>] [iterations=<N>] [distance_type=<type>]`
-
-> **Note:** The `kmeans` command does not take positional field arguments. It operates on all numeric fields from the preceding pipeline output. Use `fields` or `eval` before `kmeans` to control which numeric fields are used for clustering.
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | where durationInNanos > 0 | fields traceId, serviceName, durationInNanos | kmeans centroids=3 | fields traceId, serviceName, durationInNanos, ClusterID | head 30"}'
-```
-
-#### ml
-
-General ML command for running machine learning algorithms on query results.
-
-**Syntax**: `ml action=<algorithm> [parameters...]`
-
-Supported algorithms include: `kmeans`, `ad` (anomaly detection).
-
-> **Note:** `ml action=rcf` is not a valid action in OpenSearch 3.x PPL. Random Cut Forest anomaly detection is accessed via the `ad` command directly (see the `ad` section above), not through `ml action=rcf`.
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | where durationInNanos > 0 | ml action=kmeans centroids=3 | head 50"}'
-```
+> **Note:** `ml action=rcf` is NOT valid in OpenSearch 3.x. Use `ad` directly for Random Cut Forest.
 
 ### System Commands
 
-#### describe
+> **Caveat:** `describe` and `show datasources` are **standalone** top-level commands, NOT pipe commands. They cannot appear after `|`.
+> - ✓ `describe my-index-*`
+> - ✗ `source=my-index-* | describe`
 
-Inspect the index mapping and field types for an index.
-
-**Syntax**: `describe <index-pattern>`
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "describe otel-v1-apm-span-*"}'
+```
+describe otel-v1-apm-span-*       # Inspect index mapping/field types
+show datasources                   # List PPL data sources
 ```
 
-#### explain
+### Display
 
-Show the query execution plan (used via the `_explain` API endpoint rather than as an inline command).
-
-**Syntax**: Use the `/_plugins/_ppl/_explain` endpoint with the query body.
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl/_explain" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | where `status.code` = 2 | stats count() by serviceName"}'
+**`fieldformat <field> = <format-expr>`** — Format display without changing data.
 ```
-
-#### showdatasources
-
-List all configured data sources available for PPL queries.
-
-**Syntax**: `show datasources`
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "show datasources"}'
-```
-
-#### multisearch
-
-Execute multiple PPL queries in a single request. Each query is independent.
-
-**Syntax**: Use the `/_plugins/_ppl` endpoint with multiple queries separated by newlines (NDJSON format), or execute sequentially.
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | stats count() as total_spans"}'
-```
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=logs-otel-v1-* | stats count() as total_logs"}'
-```
-
-### Display Commands
-
-#### fieldformat
-
-Format the display of a field's values without changing the underlying data.
-
-**Syntax**: `fieldformat <field> = <format-expression>`
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | eval duration_ms = durationInNanos / 1000000 | fieldformat duration_ms = CONCAT(CAST(duration_ms AS STRING), '\'' ms'\'') | fields traceId, serviceName, duration_ms | head 10"}'
+source=otel-v1-apm-span-* | eval ms = durationInNanos / 1000000 | fieldformat ms = CONCAT(CAST(ms AS STRING), ' ms')
 ```
 
 ---
 
-## Span Expression Syntax
+## Span Expression
 
-The `span()` function buckets numeric or datetime values into intervals. Used with `stats`, `timechart`, and `chart`.
+Buckets numeric or datetime values into intervals. Used with `stats`, `timechart`, `chart`.
 
 **Syntax**: `span(<field>, <interval>)`
 
-### Supported Time Units
-
-| Unit | Description | Example |
-|------|-------------|---------|
-| `ms` | Milliseconds | `span(startTime, 500ms)` |
-| `s` | Seconds | `span(startTime, 30s)` |
-| `m` | Minutes | `span(startTime, 5m)` |
-| `h` | Hours | `span(startTime, 1h)` |
-| `d` | Days | `span(startTime, 1d)` |
-| `w` | Weeks | `span(startTime, 1w)` |
-| `M` | Months | `span(startTime, 1M)` |
-| `q` | Quarters | `span(startTime, 1q)` |
-| `y` | Years | `span(startTime, 1y)` |
-
-### Numeric Spans
-
-For numeric fields, the interval is a plain number:
+**Time units**: `ms`, `s`, `m` (minutes), `h`, `d`, `w`, `M` (months), `q` (quarters), `y`.
 
 ```
-stats count() by span(durationInNanos, 1000000000)
-```
-
-### Example
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | stats count() as span_count, avg(durationInNanos) as avg_duration by span(startTime, 1h)"}'
-```
-
-## Timechart Rate Functions
-
-Rate functions normalize aggregation values to a per-time-unit rate within `timechart`:
-
-| Function | Description |
-|----------|-------------|
-| `per_second(<agg>)` | Aggregation value per second |
-| `per_minute(<agg>)` | Aggregation value per minute |
-| `per_hour(<agg>)` | Aggregation value per hour |
-| `per_day(<agg>)` | Aggregation value per day |
-
-### Example
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | timechart span=5m per_second(count()) as requests_per_sec"}'
+source=otel-v1-apm-span-* | stats count() by span(startTime, 1h)
+source=otel-v1-apm-span-* | stats count() by span(durationInNanos, 1000000000)   # numeric, plain number
 ```
 
 ---
 
 ## Functions
 
-### Aggregation Functions
+### Aggregation (for stats, eventstats, streamstats, timechart, chart)
 
-Used with `stats`, `eventstats`, `streamstats`, `timechart`, and `chart` commands.
-
-| Function | Syntax | Description |
-|----------|--------|-------------|
-| `COUNT` | `count()` | Count of events |
-| `SUM` | `sum(field)` | Sum of numeric values |
-| `AVG` | `avg(field)` | Arithmetic mean |
-| `MAX` | `max(field)` | Maximum value |
-| `MIN` | `min(field)` | Minimum value |
-| `VAR_SAMP` | `var_samp(field)` | Sample variance |
-| `VAR_POP` | `var_pop(field)` | Population variance |
-| `STDDEV_SAMP` | `stddev_samp(field)` | Sample standard deviation |
-| `STDDEV_POP` | `stddev_pop(field)` | Population standard deviation |
-| `DISTINCT_COUNT` | `distinct_count(field)` | Count of distinct values |
-| `PERCENTILE` | `percentile(field, pct)` | Value at the given percentile |
-| `EARLIEST` | `earliest(field)` | Earliest (first chronological) value |
-| `LATEST` | `latest(field)` | Latest (most recent) value |
-| `LIST` | `list(field)` | All values as a list |
-| `VALUES` | `values(field)` | Distinct values as a list |
-| `FIRST` | `first(field)` | First value encountered |
-| `LAST` | `last(field)` | Last value encountered |
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | stats count() as total, avg(durationInNanos) as avg_ns, percentile(durationInNanos, 95) as p95_ns, distinct_count(serviceName) as services"}'
-```
-
-### Collection Functions
-
-Functions for working with multi-value fields and arrays.
-
-| Function | Syntax | Description |
-|----------|--------|-------------|
-| `ARRAY` | `array(val1, val2, ...)` | Create an array from values |
-| `SPLIT` | `split(field, delimiter)` | Split a string into an array |
-| `MVJOIN` | `mvjoin(field, delimiter)` | Join multi-value field into a string |
-| `MVCOUNT` | `mvcount(field)` | Count of values in a multi-value field |
-| `MVINDEX` | `mvindex(field, index)` | Get value at index from multi-value field |
-| `MVFIRST` | `mvfirst(field)` | First value of a multi-value field |
-| `MVLAST` | `mvlast(field)` | Last value of a multi-value field |
-| `MVAPPEND` | `mvappend(field1, field2)` | Append two multi-value fields |
-| `MVDEDUP` | `mvdedup(field)` | Remove duplicates from multi-value field |
-| `MVSORT` | `mvsort(field)` | Sort values in a multi-value field |
-| `MVZIP` | `mvzip(field1, field2, delim)` | Zip two multi-value fields together |
-| `MVRANGE` | `mvrange(start, end, step)` | Generate a range of numeric values |
-| `MVFILTER` | `mvfilter(expression)` | Filter values in a multi-value field |
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | eval tokens = array(`attributes.gen_ai.usage.input_tokens`, `attributes.gen_ai.usage.output_tokens`) | fields traceId, tokens | head 10"}'
-```
-
-### Condition Functions
-
-Functions for conditional logic and null handling.
-
-| Function | Syntax | Description |
-|----------|--------|-------------|
-| `ISNULL` | `isnull(field)` | Returns true if field is null |
-| `ISNOTNULL` | `isnotnull(field)` | Returns true if field is not null |
-| `IF` | `if(cond, true_val, false_val)` | Conditional expression |
-| `IFNULL` | `ifnull(field, default)` | Return default if field is null |
-| `NULLIF` | `nullif(val1, val2)` | Return null if val1 equals val2 |
-| `CASE` | `case(cond1, val1, cond2, val2, ..., else_val)` | Multi-branch conditional |
-| `COALESCE` | `coalesce(val1, val2, ...)` | First non-null value |
-| `LIKE` | `field LIKE 'pattern'` | Wildcard pattern match (`%` and `_`) |
-| `IN` | `field IN (val1, val2, ...)` | Check membership in a set |
-| `BETWEEN` | `field BETWEEN val1 AND val2` | Range check (inclusive) |
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | eval status_label = case(`status.code` = 0, '\''UNSET'\'', `status.code` = 1, '\''OK'\'', `status.code` = 2, '\''ERROR'\'') | stats count() by status_label"}'
-```
-
-### Conversion Functions
-
-Functions for type casting and conversion.
-
-| Function | Syntax | Description |
-|----------|--------|-------------|
-| `CAST` | `cast(field AS type)` | Cast to a specified type (STRING, INT, LONG, FLOAT, DOUBLE, BOOLEAN, DATE, TIMESTAMP) |
-| `TOSTRING` | `tostring(field)` | Convert to string |
-| `TONUMBER` | `tonumber(field)` | Convert to number |
-| `TOINT` | `toint(field)` | Convert to integer |
-| `TOLONG` | `tolong(field)` | Convert to long |
-| `TOFLOAT` | `tofloat(field)` | Convert to float |
-| `TODOUBLE` | `todouble(field)` | Convert to double |
-| `TOBOOLEAN` | `toboolean(field)` | Convert to boolean |
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | eval duration_ms = CAST(durationInNanos AS DOUBLE) / 1000000.0 | fields traceId, serviceName, duration_ms | sort - duration_ms | head 10"}'
-```
-
-### Cryptographic Functions
-
-Functions for computing hash digests.
-
-| Function | Syntax | Description |
-|----------|--------|-------------|
-| `MD5` | `md5(field)` | MD5 hash of the value |
-| `SHA1` | `sha1(field)` | SHA-1 hash of the value |
-| `SHA2` | `sha2(field, numBits)` | SHA-2 hash (numBits: 224, 256, 384, 512) |
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | eval trace_hash = md5(traceId) | fields traceId, trace_hash | head 5"}'
-```
-
-### Datetime Functions
-
-Functions for date and time manipulation.
-
-| Function | Syntax | Description |
-|----------|--------|-------------|
-| `NOW` | `now()` | Current timestamp |
-| `CURDATE` | `curdate()` | Current date |
-| `CURTIME` | `curtime()` | Current time |
-| `DATE_FORMAT` | `date_format(date, fmt)` | Format a date (`%Y-%m-%d %H:%i:%s`) |
-| `DATE_ADD` | `date_add(date, INTERVAL n unit)` | Add interval to date |
-| `DATE_SUB` | `date_sub(date, INTERVAL n unit)` | Subtract interval from date |
-| `DATEDIFF` | `datediff(date1, date2)` | Difference in days between two dates |
-| `DAY` | `day(date)` | Day of month (1–31) |
-| `MONTH` | `month(date)` | Month (1–12) |
-| `YEAR` | `year(date)` | Year |
-| `HOUR` | `hour(time)` | Hour (0–23) |
-| `MINUTE` | `minute(time)` | Minute (0–59) |
-| `SECOND` | `second(time)` | Second (0–59) |
-| `DAYOFWEEK` | `dayofweek(date)` | Day of week (1=Sun, 7=Sat) |
-| `DAYOFYEAR` | `dayofyear(date)` | Day of year (1–366) |
-| `WEEK` | `week(date)` | Week number of the year |
-| `UNIX_TIMESTAMP` | `unix_timestamp(date)` | Convert to Unix epoch seconds |
-| `FROM_UNIXTIME` | `from_unixtime(epoch)` | Convert Unix epoch to timestamp |
-| `TIMESTAMPADD` | `timestampadd(unit, n, ts)` | Add interval to timestamp |
-| `TIMESTAMPDIFF` | `timestampdiff(unit, ts1, ts2)` | Difference between timestamps in given unit |
-| `PERIOD_ADD` | `period_add(period, n)` | Add months to a period (YYMM/YYYYMM) |
-| `PERIOD_DIFF` | `period_diff(p1, p2)` | Difference in months between periods |
-| `MAKETIME` | `maketime(h, m, s)` | Create a time value |
-| `MAKEDATE` | `makedate(year, dayofyear)` | Create a date from year and day-of-year |
-| `ADDDATE` | `adddate(date, INTERVAL n unit)` | Alias for DATE_ADD |
-| `SUBDATE` | `subdate(date, INTERVAL n unit)` | Alias for DATE_SUB |
-| `SYSDATE` | `sysdate()` | Current date and time (evaluated at execution) |
-| `UTC_DATE` | `utc_date()` | Current UTC date |
-| `UTC_TIME` | `utc_time()` | Current UTC time |
-| `UTC_TIMESTAMP` | `utc_timestamp()` | Current UTC timestamp |
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | where startTime > DATE_SUB(NOW(), INTERVAL 1 HOUR) | stats count() as recent_spans by serviceName"}'
-```
-
-### Expressions
-
-Operators for arithmetic, comparison, and logical expressions used in `eval`, `where`, and other commands.
-
-#### Arithmetic Operators
-
-| Operator | Description | Example |
-|----------|-------------|---------|
-| `+` | Addition | `eval total = input_tokens + output_tokens` |
-| `-` | Subtraction | `eval gap = endTime - startTime` |
-| `*` | Multiplication | `eval cost = tokens * price_per_token` |
-| `/` | Division | `eval duration_ms = durationInNanos / 1000000` |
-
-#### Comparison Operators
-
-| Operator | Description |
+| Function | Description |
 |----------|-------------|
-| `=` | Equal to |
-| `!=` or `<>` | Not equal to |
-| `<` | Less than |
-| `>` | Greater than |
-| `<=` | Less than or equal to |
-| `>=` | Greater than or equal to |
+| `count()`, `sum(f)`, `avg(f)`, `max(f)`, `min(f)` | Basic aggregations |
+| `var_samp(f)`, `var_pop(f)`, `stddev_samp(f)`, `stddev_pop(f)` | Variance/stddev |
+| `distinct_count(f)` | Count distinct values |
+| `percentile(f, pct)` | Value at percentile |
+| `earliest(f)`, `latest(f)` | Chronological first/last |
+| `first(f)`, `last(f)` | Result-order first/last |
+| `list(f)`, `values(f)` | All / distinct values as list |
+| `covar_pop(f1, f2)`, `covar_samp(f1, f2)` | Covariance |
 
-#### Logical Operators
+> **Note:** `corr()` is NOT supported in OpenSearch 3.x PPL. Use `covar_samp` with separate `stddev` calls to approximate Pearson correlation.
 
-| Operator | Description |
+### Condition
+
+| Function | Description |
 |----------|-------------|
-| `AND` | Logical AND |
-| `OR` | Logical OR |
-| `NOT` | Logical NOT |
-| `XOR` | Logical exclusive OR |
+| `isnull(f)`, `isnotnull(f)` | Null check |
+| `if(cond, true_val, false_val)` | Conditional |
+| `ifnull(f, default)`, `nullif(a, b)`, `coalesce(v1, v2, ...)` | Null handling |
+| `case(cond1, val1, cond2, val2, ..., else_val)` | Multi-branch |
+| `field LIKE 'pattern'`, `field IN (v1, ...)`, `field BETWEEN a AND b` | Used in `where` |
 
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | eval duration_ms = durationInNanos / 1000000, total_tokens = `attributes.gen_ai.usage.input_tokens` + `attributes.gen_ai.usage.output_tokens` | where duration_ms > 1000 AND total_tokens > 0 | fields traceId, serviceName, duration_ms, total_tokens | head 10"}'
+```
+source=otel-v1-apm-span-* | eval label = case(`status.code` = 0, 'UNSET', `status.code` = 1, 'OK', `status.code` = 2, 'ERROR')
 ```
 
-### IP Functions
+### Conversion
 
-Functions for IP address operations.
+| Function | Description |
+|----------|-------------|
+| `cast(f AS type)` | Cast (STRING, INT, LONG, FLOAT, DOUBLE, BOOLEAN, DATE, TIMESTAMP) |
+| `tostring(f)`, `tonumber(f)`, `toint(f)`, `tolong(f)`, `tofloat(f)`, `todouble(f)`, `toboolean(f)` | Type shortcuts |
 
-| Function | Syntax | Description |
-|----------|--------|-------------|
-| `CIDRMATCH` | `cidrmatch(ip_field, 'cidr')` | Check if IP is within a CIDR range |
-| `GEOIP` | `geoip(ip_field)` | Geo-locate an IP address (returns country, region, city, lat/lon) |
+### Datetime
 
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | where isnotnull(`attributes.net.peer.ip`) | where cidrmatch(`attributes.net.peer.ip`, '\''10.0.0.0/8'\'') | fields traceId, `attributes.net.peer.ip`, serviceName | head 10"}'
+| Function | Description |
+|----------|-------------|
+| `now()`, `curdate()`, `curtime()`, `sysdate()` | Current time |
+| `utc_date()`, `utc_time()`, `utc_timestamp()` | UTC variants |
+| `date_format(date, fmt)` | Format (`%Y-%m-%d %H:%i:%s`) |
+| `date_add(d, INTERVAL n unit)`, `date_sub(d, INTERVAL n unit)`, `adddate`, `subdate` | Add/subtract |
+| `datediff(d1, d2)` | Days between |
+| `timestampadd(unit, n, ts)`, `timestampdiff(unit, t1, t2)` | Precise delta |
+| `day()`, `month()`, `year()`, `hour()`, `minute()`, `second()` | Extract components |
+| `dayofweek()`, `dayofyear()`, `week()` | Calendar components |
+| `unix_timestamp(d)`, `from_unixtime(epoch)` | Epoch conversion |
+| `maketime(h, m, s)`, `makedate(year, doy)` | Construct |
+| `period_add(p, n)`, `period_diff(p1, p2)` | YYMM/YYYYMM arithmetic |
+
+```
+source=otel-v1-apm-span-* | where startTime > DATE_SUB(NOW(), INTERVAL 1 HOUR)
 ```
 
-### JSON Functions
+### String
 
-Functions for working with JSON data.
+| Function | Description |
+|----------|-------------|
+| `concat(...)`, `length(s)`, `char_length(s)`, `octet_length(s)`, `bit_length(s)` | Basic |
+| `lower(s)`, `upper(s)`, `reverse(s)` | Case / reverse |
+| `trim(s)`, `ltrim(s)`, `rtrim(s)` | Trim |
+| `substring(s, start [, len])`, `substr`, `mid`, `left(s, n)`, `right(s, n)` | Substring |
+| `replace(s, from, to)`, `regexp_replace(s, pattern, repl)` | Replace |
+| `locate(sub, s [, pos])`, `position(sub IN s)`, `instr(s, sub)` | Search |
+| `lpad(s, len, pad)`, `rpad(s, len, pad)`, `space(n)`, `repeat(s, n)` | Padding |
+| `strcmp(a, b)`, `ascii(s)`, `format(val, decimals)` | Misc |
+| `regexp(s, pat)`, `regexp_extract(s, pat [, group])` | Regex (returns 0/1 or group) |
+| `field(s, v1, ...)`, `find_in_set(s, list)` | Position in list |
+| `insert(s, pos, len, new)` | Insert |
 
-| Function | Syntax | Description |
-|----------|--------|-------------|
-| `JSON_EXTRACT` | `json_extract(field, path)` | Extract value at JSON path |
-| `JSON_KEYS` | `json_keys(field)` | Get all keys from a JSON object |
-| `JSON_VALID` | `json_valid(field)` | Check if value is valid JSON |
-| `JSON_ARRAY` | `json_array(val1, val2, ...)` | Create a JSON array |
-| `JSON_OBJECT` | `json_object(key1, val1, ...)` | Create a JSON object |
-| `JSON_ARRAY_LENGTH` | `json_array_length(field)` | Length of a JSON array |
-| `JSON_EXTRACT_PATH_TEXT` | `json_extract_path_text(field, path)` | Extract value as text from JSON path |
-| `TO_JSON_STRING` | `to_json_string(field)` | Convert value to JSON string |
+### Math
 
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | where json_valid(`attributes.gen_ai.tool.call.arguments`) | eval tool_args = json_extract(`attributes.gen_ai.tool.call.arguments`, '\''$'\'') | fields traceId, `attributes.gen_ai.tool.name`, tool_args | head 10"}'
+| Function | Description |
+|----------|-------------|
+| `abs`, `ceil`, `floor`, `round(v [, dec])`, `truncate(v, dec)`, `sign` | Rounding / sign |
+| `sqrt`, `pow(b, e)`, `exp`, `ln`, `log`, `log2`, `log10` | Power / log |
+| `mod(a, b)`, `conv(v, from, to)`, `crc32` | Misc |
+| `sin`, `cos`, `tan`, `asin`, `acos`, `atan`, `atan2(y, x)`, `cot` | Trig |
+| `degrees(r)`, `radians(d)`, `pi()`, `e()`, `rand([seed])` | Constants / conversion |
+
+### Collection / Multi-Value
+
+| Function | Description |
+|----------|-------------|
+| `array(v1, v2, ...)`, `split(f, delim)` | Construct |
+| `mvcount(f)`, `mvindex(f, i)`, `mvfirst(f)`, `mvlast(f)` | Access |
+| `mvappend(f1, f2)`, `mvjoin(f, delim)`, `mvzip(f1, f2, delim)` | Combine |
+| `mvdedup(f)`, `mvsort(f)`, `mvfilter(expr)` | Transform |
+| `mvrange(start, end, step)` | Generate |
+
+### JSON
+
+| Function | Description |
+|----------|-------------|
+| `json_extract(f, path)`, `json_extract_path_text(f, path)` | Extract |
+| `json_keys(f)`, `json_valid(f)`, `json_array_length(f)` | Inspect |
+| `json_array(v1, ...)`, `json_object(k1, v1, ...)`, `to_json_string(f)` | Construct |
+
+### Crypto / IP / System
+
+| Function | Description |
+|----------|-------------|
+| `md5(f)`, `sha1(f)`, `sha2(f, numBits)` | Hash (numBits: 224/256/384/512) |
+| `cidrmatch(ip, 'cidr')` | CIDR range check |
+| `geoip(ip)` | Geo lookup (country, region, city, lat/lon) |
+| `typeof(f)` | Data type of value |
+
+### Relevance (Full-Text Search)
+
+| Function | Description |
+|----------|-------------|
+| `match(field, query)`, `match_query(...)` | Full-text match |
+| `match_phrase(field, phrase)`, `match_phrase_prefix(...)`, `match_bool_prefix(...)` | Phrase / prefix |
+| `multi_match([f1, f2], q)` | Multi-field match |
+| `query_string([f1, f2], q)`, `simple_query_string(...)` | Lucene/simplified query syntax |
+| `wildcard_query(f, pattern)` | `*` and `?` wildcards |
+| `highlight(f)`, `score(rf)`, `scorequery(rf)` | Highlighting / scoring |
+
+```
+source=logs-otel-v1-* | where match(body, 'timeout error')
 ```
 
-### Math Functions
+### Expressions / Operators
 
-Functions for mathematical operations.
-
-| Function | Syntax | Description |
-|----------|--------|-------------|
-| `ABS` | `abs(val)` | Absolute value |
-| `CEIL` | `ceil(val)` | Round up to nearest integer |
-| `FLOOR` | `floor(val)` | Round down to nearest integer |
-| `ROUND` | `round(val [, decimals])` | Round to N decimal places |
-| `SQRT` | `sqrt(val)` | Square root |
-| `POW` | `pow(base, exp)` | Exponentiation |
-| `MOD` | `mod(a, b)` | Modulo (remainder) |
-| `LOG` | `log(val)` | Natural logarithm |
-| `LOG2` | `log2(val)` | Base-2 logarithm |
-| `LOG10` | `log10(val)` | Base-10 logarithm |
-| `LN` | `ln(val)` | Natural logarithm (alias for LOG) |
-| `EXP` | `exp(val)` | e raised to the power of val |
-| `SIGN` | `sign(val)` | Sign of value (-1, 0, 1) |
-| `TRUNCATE` | `truncate(val, decimals)` | Truncate to N decimal places |
-| `PI` | `pi()` | Value of π |
-| `E` | `e()` | Value of Euler's number |
-| `RAND` | `rand([seed])` | Random float between 0 and 1 |
-| `ACOS` | `acos(val)` | Arc cosine |
-| `ASIN` | `asin(val)` | Arc sine |
-| `ATAN` | `atan(val)` | Arc tangent |
-| `ATAN2` | `atan2(y, x)` | Two-argument arc tangent |
-| `COS` | `cos(val)` | Cosine |
-| `SIN` | `sin(val)` | Sine |
-| `TAN` | `tan(val)` | Tangent |
-| `COT` | `cot(val)` | Cotangent |
-| `DEGREES` | `degrees(radians)` | Convert radians to degrees |
-| `RADIANS` | `radians(degrees)` | Convert degrees to radians |
-| `CONV` | `conv(val, from_base, to_base)` | Convert between number bases |
-| `CRC32` | `crc32(val)` | CRC-32 checksum |
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | eval duration_ms = round(durationInNanos / 1000000.0, 2) | where duration_ms > 0 | fields traceId, serviceName, duration_ms | sort - duration_ms | head 10"}'
-```
-
-### Relevance Functions
-
-Full-text search functions for relevance-based querying.
-
-| Function | Syntax | Description |
-|----------|--------|-------------|
-| `MATCH` | `match(field, query)` | Full-text match on a single field |
-| `MATCH_PHRASE` | `match_phrase(field, phrase)` | Exact phrase match |
-| `MATCH_BOOL_PREFIX` | `match_bool_prefix(field, query)` | Boolean prefix match |
-| `MATCH_PHRASE_PREFIX` | `match_phrase_prefix(field, prefix)` | Phrase prefix match |
-| `MULTI_MATCH` | `multi_match([field1, field2], query)` | Match across multiple fields |
-| `QUERY_STRING` | `query_string([field1, field2], query)` | Lucene query string syntax |
-| `SIMPLE_QUERY_STRING` | `simple_query_string([field1, field2], query)` | Simplified query string |
-| `HIGHLIGHT` | `highlight(field)` | Return highlighted matching fragments |
-| `SCORE` | `score(relevance_func)` | Return relevance score |
-| `SCOREQUERY` | `scorequery(relevance_func)` | Filter by relevance score |
-| `MATCH_QUERY` | `match_query(field, query)` | Alias for MATCH |
-| `WILDCARD_QUERY` | `wildcard_query(field, pattern)` | Wildcard pattern match (`*` and `?`) |
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=logs-otel-v1-* | where match(body, '\''timeout error'\'') | fields traceId, severityText, body | head 10"}'
-```
-
-### Statistical Functions
-
-Functions for computing statistical correlations and covariances.
-
-| Function | Syntax | Description |
-|----------|--------|-------------|
-| `COVAR_POP` | `covar_pop(field1, field2)` | Population covariance |
-| `COVAR_SAMP` | `covar_samp(field1, field2)` | Sample covariance |
-
-> **Note:** `corr()` is not a recognized stats aggregation function in OpenSearch 3.x PPL. To approximate Pearson correlation, use `eval` with manual calculation or compute covariance and standard deviations separately. The `covar_samp` and `covar_pop` functions are supported.
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | where `attributes.gen_ai.usage.input_tokens` > 0 | stats covar_samp(`attributes.gen_ai.usage.input_tokens`, durationInNanos) as token_duration_covar"}'
-```
-
-### String Functions
-
-Functions for string manipulation.
-
-| Function | Syntax | Description |
-|----------|--------|-------------|
-| `CONCAT` | `concat(str1, str2, ...)` | Concatenate strings |
-| `LENGTH` | `length(str)` | String length in bytes |
-| `LOWER` | `lower(str)` | Convert to lowercase |
-| `UPPER` | `upper(str)` | Convert to uppercase |
-| `TRIM` | `trim(str)` | Remove leading/trailing whitespace |
-| `LTRIM` | `ltrim(str)` | Remove leading whitespace |
-| `RTRIM` | `rtrim(str)` | Remove trailing whitespace |
-| `SUBSTRING` | `substring(str, start [, len])` | Extract substring |
-| `LEFT` | `left(str, len)` | Leftmost N characters |
-| `RIGHT` | `right(str, len)` | Rightmost N characters |
-| `REPLACE` | `replace(str, from, to)` | Replace occurrences |
-| `REVERSE` | `reverse(str)` | Reverse a string |
-| `LOCATE` | `locate(substr, str [, pos])` | Position of substring |
-| `POSITION` | `position(substr IN str)` | Position of substring |
-| `ASCII` | `ascii(str)` | ASCII code of first character |
-| `CHAR_LENGTH` | `char_length(str)` | Character count |
-| `CHARACTER_LENGTH` | `character_length(str)` | Alias for CHAR_LENGTH |
-| `OCTET_LENGTH` | `octet_length(str)` | Byte count |
-| `BIT_LENGTH` | `bit_length(str)` | Bit count |
-| `LPAD` | `lpad(str, len, pad)` | Left-pad to length |
-| `RPAD` | `rpad(str, len, pad)` | Right-pad to length |
-| `SPACE` | `space(n)` | String of N spaces |
-| `REPEAT` | `repeat(str, n)` | Repeat string N times |
-| `STRCMP` | `strcmp(str1, str2)` | Compare strings (-1, 0, 1) |
-| `SUBSTR` | `substr(str, start [, len])` | Alias for SUBSTRING |
-| `MID` | `mid(str, start, len)` | Alias for SUBSTRING |
-| `FIELD` | `field(str, val1, val2, ...)` | Index of str in value list |
-| `FIND_IN_SET` | `find_in_set(str, strlist)` | Position in comma-separated list |
-| `FORMAT` | `format(val, decimals)` | Format number with commas and decimals |
-| `INSERT` | `insert(str, pos, len, newstr)` | Insert string at position |
-| `INSTR` | `instr(str, substr)` | Position of first occurrence |
-| `REGEXP` | `regexp(str, pattern)` | Regex match (returns 1 or 0) |
-| `REGEXP_EXTRACT` | `regexp_extract(str, pattern [, group])` | Extract regex capture group |
-| `REGEXP_REPLACE` | `regexp_replace(str, pattern, replacement)` | Replace regex matches |
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=logs-otel-v1-* | eval body_lower = lower(body) | where body_lower like '\''%exception%'\'' | eval short_body = left(body, 200) | fields traceId, severityText, short_body | head 10"}'
-```
-
-### System Functions
-
-| Function | Syntax | Description |
-|----------|--------|-------------|
-| `TYPEOF` | `typeof(field)` | Returns the data type of a field value |
-
-```bash
-curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
-  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
-  -H 'Content-Type: application/json' \
-  -d '{"query": "source=otel-v1-apm-span-* | eval type_of_duration = typeof(durationInNanos) | fields traceId, durationInNanos, type_of_duration | head 5"}'
-```
+- **Arithmetic**: `+`, `-`, `*`, `/`
+- **Comparison**: `=`, `!=` or `<>`, `<`, `>`, `<=`, `>=`
+- **Logical**: `AND`, `OR`, `NOT`, `XOR`
 
 ---
 
-## Grammar Source
-
-This PPL reference is sourced from the `opensearch-project/sql` repository's `docs/user/ppl/` directory.
-
-Repository: https://github.com/opensearch-project/sql
-
-The PPL grammar is maintained as part of the OpenSearch SQL plugin. For the latest syntax additions and changes, consult the repository documentation directly.
-
 ## References
 
-- [PPL Language Reference](https://github.com/opensearch-project/sql/blob/main/docs/user/ppl/index.md) — Official PPL syntax documentation. Fetch this if queries fail due to OpenSearch version differences or new syntax.
+- [Official PPL docs](https://github.com/opensearch-project/sql/blob/main/docs/user/ppl/index.md) — Fetch if queries fail due to OpenSearch version differences or new syntax.

--- a/skills/ppl-reference/SKILL.md
+++ b/skills/ppl-reference/SKILL.md
@@ -12,7 +12,7 @@ Piped Processing Language (PPL) for OpenSearch. Queries use pipe-delimited synta
 Field names containing dots, `@`, or other special characters must be enclosed in backticks:
 
 ```
-`status.code`, `attributes.gen_ai.usage.input_tokens`, `@timestamp`, `geo.src`
+`attributes.gen_ai.operation.name`, `attributes.gen_ai.usage.input_tokens`, `status.code`, `events.attributes.exception.type`, `@timestamp`
 ```
 
 Critical for OTel attribute fields which use dotted naming conventions.
@@ -39,17 +39,17 @@ source=otel-v1-apm-span-* | head 10
 
 **`where <condition>`** — Filter results. Operators: `=`, `!=`, `<`, `>`, `<=`, `>=`, `AND`, `OR`, `NOT`, `LIKE`, `IN`, `BETWEEN`, `IS NULL`, `IS NOT NULL`.
 ```
-source=otel-v1-apm-span-* | where `status.code` = 2
+source=otel-v1-apm-span-* | where `status.code` = 2 | head 10
 ```
 
 **`fields [+|-] <field-list>`** — Select (`+`) or exclude (`-`) fields. Default is `+`.
 ```
-source=otel-v1-apm-span-* | fields traceId, serviceName, durationInNanos
+source=otel-v1-apm-span-* | fields traceId, spanId, serviceName, durationInNanos | head 10
 ```
 
 **`stats <aggregation>... [by <field-list>]`** — Aggregate. Functions: `count()`, `sum()`, `avg()`, `max()`, `min()`, `var_samp()`, `var_pop()`, `stddev_samp()`, `stddev_pop()`, `distinct_count()`, `percentile(field, pct)`, `earliest()`, `latest()`, `list()`, `values()`, `first()`, `last()`.
 ```
-source=otel-v1-apm-span-* | stats count() as n, avg(durationInNanos) as avg_dur by serviceName
+source=otel-v1-apm-span-* | stats count() as span_count, avg(durationInNanos) as avg_duration by serviceName
 ```
 
 **`sort [+|-] <field>`** — `+` ascending (default), `-` descending.
@@ -57,14 +57,14 @@ source=otel-v1-apm-span-* | stats count() as n, avg(durationInNanos) as avg_dur 
 source=otel-v1-apm-span-* | sort - durationInNanos | head 10
 ```
 
-**`head [N]`** — Limit (default N=10). **`reverse`** — Reverse order.
+**`head [N]`** — Limit (default N=10).
 ```
 source=otel-v1-apm-span-* | head 5
 ```
 
 **`eval <field> = <expression>`** — Compute new fields.
 ```
-source=otel-v1-apm-span-* | eval duration_ms = durationInNanos / 1000000
+source=otel-v1-apm-span-* | eval duration_ms = durationInNanos / 1000000 | fields traceId, serviceName, duration_ms | sort - duration_ms | head 10
 ```
 
 **`dedup [N] <field-list> [keepempty=<bool>] [consecutive=<bool>]`** — Remove duplicates.
@@ -72,27 +72,40 @@ source=otel-v1-apm-span-* | eval duration_ms = durationInNanos / 1000000
 > **Caveat:** `dedup` may throw a ClassCastException on fields with mixed types. Ensure consistent type.
 
 ```
-source=otel-v1-apm-span-* | dedup serviceName
+source=otel-v1-apm-span-* | dedup serviceName | fields serviceName
 ```
 
 **`rename <old> AS <new>`** — Rename fields.
 ```
-source=otel-v1-apm-span-* | rename serviceName as service, durationInNanos as duration
+source=otel-v1-apm-span-* | rename serviceName as service, durationInNanos as duration | fields traceId, service, duration | head 10
 ```
 
-**`top [N] <field> [by <group>]`** / **`rare <field> [by <group>]`** — Most/least frequent values.
+**`top [N] <field> [by <group>]`** — Most frequent values.
 ```
 source=otel-v1-apm-span-* | top 5 serviceName
 ```
 
+**`rare <field> [by <group>]`** — Least frequent values.
+```
+source=otel-v1-apm-span-* | rare `attributes.gen_ai.operation.name`
+```
+
 **`table <field-list>`** — Tabular display (alias for `fields` in some contexts).
+```
+source=otel-v1-apm-span-* | where `status.code` = 2 | table traceId, spanId, serviceName, name | head 10
+```
+
+**`reverse`** — Reverse the order of results.
+```
+source=otel-v1-apm-span-* | sort startTime | head 20 | reverse
+```
 
 ### Time-Series
 
 **`timechart span=<interval> <aggregation>... [by <field>]`** — Time-bucketed aggregation. Rate functions: `per_second()`, `per_minute()`, `per_hour()`, `per_day()`.
 ```
-source=otel-v1-apm-span-* | timechart span=5m count() as n by serviceName
-source=otel-v1-apm-span-* | timechart span=1h per_minute(count()) as spans_per_min
+source=otel-v1-apm-span-* | timechart span=5m count() as span_count by serviceName
+source=otel-v1-apm-span-* | timechart span=1h per_minute(count()) as spans_per_min by serviceName
 ```
 
 **`chart <aggregation>... by <field>`** — General charting.
@@ -107,7 +120,7 @@ source=otel-v1-apm-span-* | stats count() by span(durationInNanos, 1000000000)
 
 **`trendline [sort <field>] sma(<period>, <field>) [as <alias>]`** — Simple moving average.
 ```
-source=otel-v1-apm-span-* | trendline sort startTime sma(10, durationInNanos) as avg_duration
+source=otel-v1-apm-span-* | trendline sort startTime sma(10, durationInNanos) as avg_duration | fields startTime, durationInNanos, avg_duration | head 50
 ```
 
 **`streamstats <aggregation>... [by <field>]`** — Running cumulative stats.
@@ -115,7 +128,7 @@ source=otel-v1-apm-span-* | trendline sort startTime sma(10, durationInNanos) as
 > **Caveat:** Processes all rows in memory. Always add `| head N` before `streamstats` to limit data volume.
 
 ```
-source=otel-v1-apm-span-* | sort startTime | head 50 | streamstats count() as running_count
+source=otel-v1-apm-span-* | sort startTime | head 50 | streamstats count() as running_count, sum(`attributes.gen_ai.usage.input_tokens`) as cumulative_tokens | fields startTime, running_count, cumulative_tokens
 ```
 
 **`eventstats <aggregation>... [by <field>]`** — Add aggregation as new field without collapsing rows.
@@ -123,7 +136,7 @@ source=otel-v1-apm-span-* | sort startTime | head 50 | streamstats count() as ru
 > **Caveat:** Processes all rows in memory. Always add `| head N` before `eventstats`.
 
 ```
-source=otel-v1-apm-span-* | head 100 | eventstats avg(durationInNanos) as avg_svc by serviceName | eval deviation = durationInNanos - avg_svc
+source=otel-v1-apm-span-* | head 100 | eventstats avg(durationInNanos) as avg_svc_duration by serviceName | eval deviation = durationInNanos - avg_svc_duration | fields traceId, serviceName, durationInNanos, avg_svc_duration, deviation | sort - deviation | head 20
 ```
 
 ### Parse / Extract
@@ -133,7 +146,7 @@ source=otel-v1-apm-span-* | head 100 | eventstats avg(durationInNanos) as avg_sv
 > **Caveat:** May silently drop extracted fields on some OpenSearch versions. Use `grok` or `rex` if `parse` misbehaves.
 
 ```
-source=logs-otel-v1-* | parse body '(?P<level>\w+): (?P<msg>.+)'
+source=logs-otel-v1-* | parse body '(?P<level>\w+): (?P<msg>.+)' | fields level, msg | head 10
 ```
 
 **`grok <field> '<grok-pattern>'`** — Extract via named Grok patterns.
@@ -141,17 +154,22 @@ source=logs-otel-v1-* | parse body '(?P<level>\w+): (?P<msg>.+)'
 > **Caveat:** Processes all rows in memory. Always add `| head N` before `grok`.
 
 ```
-source=logs-otel-v1-* | head 100 | grok body '%{LOGLEVEL:level} %{GREEDYDATA:message}'
+source=logs-otel-v1-* | head 100 | grok body '%{LOGLEVEL:level} %{GREEDYDATA:message}' | fields level, message | head 10
 ```
 
 **`rex field=<field> '<regex>'`** — Splunk-compatible regex extract.
 ```
-source=logs-otel-v1-* | rex field=body '(?<statuscode>\d{3})'
+source=logs-otel-v1-* | rex field=body '(?<statuscode>\d{3})' | fields statuscode, body | head 10
+```
+
+**`regex`** — Filter results using a regular expression match on a field (used within `where`).
+```
+source=logs-otel-v1-* | where body like '%error%' | fields traceId, body, severityText | head 10
 ```
 
 **`patterns <field>`** — Auto-cluster similar log messages.
 ```
-source=logs-otel-v1-* | patterns body
+source=logs-otel-v1-* | patterns body | fields body, patterns_field | head 20
 ```
 
 **`spath input=<field> [path=<path>] [output=<field>]`** — Extract from structured data (JSON/XML).
@@ -159,14 +177,14 @@ source=logs-otel-v1-* | patterns body
 > **Note:** Verify the target field exists (`describe <index>`) before using `spath`.
 
 ```
-source=otel-v1-apm-span-* | where isnotnull(`attributes.gen_ai.tool.name`) | spath input=`attributes.gen_ai.tool.name`
+source=otel-v1-apm-span-* | where isnotnull(`attributes.gen_ai.tool.name`) | spath input=`attributes.gen_ai.tool.name` | head 10
 ```
 
 ### Join / Lookup / Subquery
 
 **`join left=<alias> right=<alias> ON <condition> <right-source>`** — Types: `inner`, `left`, `right`, `cross`.
 ```
-source=otel-v1-apm-span-* | join left=s right=l ON s.traceId = l.traceId logs-otel-v1-*
+source=otel-v1-apm-span-* | join left=s right=l ON s.traceId = l.traceId logs-otel-v1-* | fields s.spanId, s.name, l.severityText, l.body | head 10
 ```
 
 **`lookup <lookup-index> <match-field> [AS <alias>] [OUTPUT <field-list>]`** — Enrich from another index.
@@ -174,26 +192,34 @@ source=otel-v1-apm-span-* | join left=s right=l ON s.traceId = l.traceId logs-ot
 > **Note:** The service map index (`otel-v2-apm-service-map`) uses `sourceNode`/`targetNode`, not `serviceName`.
 
 ```
-source=otel-v1-apm-span-* | lookup otel-v2-apm-service-map serviceName AS `sourceNode`
+source=otel-v1-apm-span-* | lookup otel-v2-apm-service-map serviceName AS `sourceNode` | fields serviceName, `targetNode`, durationInNanos | head 10
 ```
 
 **`graphlookup <index> connectFromField=<f> connectToField=<f> [maxDepth=<N>]`** — Graph traversal.
 
 > **Caveat:** Limited support in OpenSearch 3.x PPL. Test before relying on this.
 
+```
+source=otel-v2-apm-service-map | graphlookup otel-v2-apm-service-map connectFromField=`destination.domain` connectToField=serviceName maxDepth=3 as dependencies | head 10
+```
+
 **`where <field> IN [ source=<index> | ... | fields <field> ]`** — Subquery filter.
 ```
-source=otel-v1-apm-span-* | where traceId IN [ source=otel-v1-apm-span-* | where `status.code` = 2 | fields traceId ]
+source=otel-v1-apm-span-* | where traceId IN [ source=otel-v1-apm-span-* | where `status.code` = 2 | fields traceId ] | fields traceId, spanId, serviceName, name | head 20
 ```
 
 **`append [ source=<index> | ... ]`** — Append rows from another query.
 ```
-source=otel-v1-apm-span-* | stats count() as cnt by serviceName | append [ source=logs-otel-v1-* | stats count() as cnt by `resource.attributes.service.name` ]
+source=otel-v1-apm-span-* | stats count() as cnt by serviceName | append [ source=logs-otel-v1-* | stats count() as cnt by `resource.attributes.service.name` ] | head 20
 ```
 
 **`appendcol [ <commands> ]`** — Append columns from a sub-pipeline.
 
 > **Caveat:** `source=` is NOT valid inside `appendcol[]` — it operates on the current result set. Use `append` if you need data from another index.
+
+```
+source=otel-v1-apm-span-* | stats count() as span_count, avg(durationInNanos) as avg_dur | appendcol [ stats max(durationInNanos) as max_dur ]
+```
 
 **`appendpipe [ <commands> ]`** — Append results of sub-pipeline on current data.
 ```
@@ -211,24 +237,54 @@ source=otel-v1-apm-span-* | eval tokens = `attributes.gen_ai.usage.input_tokens`
 ```
 
 **`flatten <field>`** — Flatten nested fields to top level.
+```
+source=otel-v1-apm-span-* | flatten events | head 10
+```
+
 **`expand <field>`** / **`mvexpand <field>`** — Expand array/multi-value fields into separate rows.
+```
+source=otel-v1-apm-span-* | expand events | fields traceId, spanId, events | head 20
+source=otel-v1-apm-span-* | mvexpand events | fields traceId, spanId, events | head 20
+```
+
 **`transpose [<N>]`** — Pivot rows into columns.
+```
+source=otel-v1-apm-span-* | stats count() as cnt by serviceName | transpose
+```
+
 **`mvcombine <field>`** — Combine rows with same key into multi-value field.
+```
+source=otel-v1-apm-span-* | fields traceId, serviceName | mvcombine serviceName | head 10
+```
 
 **`nomv <field>`** — Multi-value → single-value.
 
 > **Caveat:** Only works on string arrays. Use `flatten` or `expand` for nested object arrays.
 
+```
+source=otel-v1-apm-span-* | nomv events | fields traceId, events | head 10
+```
+
 **`convert <function>(<field>) [as <alias>]`** — Type conversion. Functions: `auto()`, `num()`, `ip()`, `ctime()`, `dur2sec()`, `mktime()`, `mstime()`, `rmcomma()`, `rmunit()`, `memk()`, `none()`.
+```
+source=otel-v1-apm-span-* | eval duration_str = CAST(durationInNanos AS STRING) | convert num(duration_str) as duration_num | fields traceId, duration_num | head 10
+```
 
 **`eval <field> = replace(<field>, '<old>', '<new>')`** — Replace values via `replace()` string function.
+```
+source=logs-otel-v1-* | eval severityText = replace(severityText, 'ERROR', 'ERR') | fields severityText, body | head 10
+```
 
 ### Totals
 
 **`addcoltotals [<field-list>]`** — Add summary row with column totals.
-**`addtotals [row=<bool>] [col=<bool>] [<field-list>]`** — Add row with sum of numeric fields.
 ```
 source=otel-v1-apm-span-* | stats count() as cnt by serviceName | addcoltotals
+```
+
+**`addtotals [row=<bool>] [col=<bool>] [<field-list>]`** — Add row with sum of numeric fields.
+```
+source=otel-v1-apm-span-* | stats sum(`attributes.gen_ai.usage.input_tokens`) as input_tok, sum(`attributes.gen_ai.usage.output_tokens`) as output_tok by serviceName | addtotals
 ```
 
 ### ML
@@ -238,7 +294,7 @@ source=otel-v1-apm-span-* | stats count() as cnt by serviceName | addcoltotals
 > **Note:** `ad` takes no positional field argument; it auto-detects from preceding `stats`/`eval` output.
 
 ```
-source=otel-v1-apm-span-* | where durationInNanos > 0 | ad time_field=startTime number_of_trees=100
+source=otel-v1-apm-span-* | where durationInNanos > 0 | ad time_field=startTime number_of_trees=100 time_zone="UTC" | head 50
 ```
 
 **`kmeans [centroids=<N>] [iterations=<N>] [distance_type=<type>]`** — K-means clustering.
@@ -246,12 +302,16 @@ source=otel-v1-apm-span-* | where durationInNanos > 0 | ad time_field=startTime 
 > **Note:** No positional field args; operates on all numeric fields from preceding output. Use `fields` to control input.
 
 ```
-source=otel-v1-apm-span-* | fields durationInNanos | kmeans centroids=3
+source=otel-v1-apm-span-* | where durationInNanos > 0 | fields traceId, serviceName, durationInNanos | kmeans centroids=3 | fields traceId, serviceName, durationInNanos, ClusterID | head 30
 ```
 
 **`ml action=<algorithm>`** — General ML command. Supported: `kmeans`, `ad`.
 
 > **Note:** `ml action=rcf` is NOT valid in OpenSearch 3.x. Use `ad` directly for Random Cut Forest.
+
+```
+source=otel-v1-apm-span-* | where durationInNanos > 0 | ml action=kmeans centroids=3 | head 50
+```
 
 ### System Commands
 
@@ -268,7 +328,7 @@ show datasources                   # List PPL data sources
 
 **`fieldformat <field> = <format-expr>`** — Format display without changing data.
 ```
-source=otel-v1-apm-span-* | eval ms = durationInNanos / 1000000 | fieldformat ms = CONCAT(CAST(ms AS STRING), ' ms')
+source=otel-v1-apm-span-* | eval duration_ms = durationInNanos / 1000000 | fieldformat duration_ms = CONCAT(CAST(duration_ms AS STRING), ' ms') | fields traceId, serviceName, duration_ms | head 10
 ```
 
 ---
@@ -282,7 +342,7 @@ Buckets numeric or datetime values into intervals. Used with `stats`, `timechart
 **Time units**: `ms`, `s`, `m` (minutes), `h`, `d`, `w`, `M` (months), `q` (quarters), `y`.
 
 ```
-source=otel-v1-apm-span-* | stats count() by span(startTime, 1h)
+source=otel-v1-apm-span-* | stats count() as span_count, avg(durationInNanos) as avg_duration by span(startTime, 1h)
 source=otel-v1-apm-span-* | stats count() by span(durationInNanos, 1000000000)   # numeric, plain number
 ```
 
@@ -303,7 +363,15 @@ source=otel-v1-apm-span-* | stats count() by span(durationInNanos, 1000000000)  
 | `list(f)`, `values(f)` | All / distinct values as list |
 | `covar_pop(f1, f2)`, `covar_samp(f1, f2)` | Covariance |
 
+```
+source=otel-v1-apm-span-* | stats count() as total, avg(durationInNanos) as avg_ns, percentile(durationInNanos, 95) as p95_ns, distinct_count(serviceName) as services
+```
+
 > **Note:** `corr()` is NOT supported in OpenSearch 3.x PPL. Use `covar_samp` with separate `stddev` calls to approximate Pearson correlation.
+
+```
+source=otel-v1-apm-span-* | where `attributes.gen_ai.usage.input_tokens` > 0 | stats covar_samp(`attributes.gen_ai.usage.input_tokens`, durationInNanos) as token_duration_covar
+```
 
 ### Condition
 
@@ -316,7 +384,7 @@ source=otel-v1-apm-span-* | stats count() by span(durationInNanos, 1000000000)  
 | `field LIKE 'pattern'`, `field IN (v1, ...)`, `field BETWEEN a AND b` | Used in `where` |
 
 ```
-source=otel-v1-apm-span-* | eval label = case(`status.code` = 0, 'UNSET', `status.code` = 1, 'OK', `status.code` = 2, 'ERROR')
+source=otel-v1-apm-span-* | eval status_label = case(`status.code` = 0, 'UNSET', `status.code` = 1, 'OK', `status.code` = 2, 'ERROR') | stats count() by status_label
 ```
 
 ### Conversion
@@ -325,6 +393,10 @@ source=otel-v1-apm-span-* | eval label = case(`status.code` = 0, 'UNSET', `statu
 |----------|-------------|
 | `cast(f AS type)` | Cast (STRING, INT, LONG, FLOAT, DOUBLE, BOOLEAN, DATE, TIMESTAMP) |
 | `tostring(f)`, `tonumber(f)`, `toint(f)`, `tolong(f)`, `tofloat(f)`, `todouble(f)`, `toboolean(f)` | Type shortcuts |
+
+```
+source=otel-v1-apm-span-* | eval duration_ms = CAST(durationInNanos AS DOUBLE) / 1000000.0 | fields traceId, serviceName, duration_ms | sort - duration_ms | head 10
+```
 
 ### Datetime
 
@@ -343,7 +415,7 @@ source=otel-v1-apm-span-* | eval label = case(`status.code` = 0, 'UNSET', `statu
 | `period_add(p, n)`, `period_diff(p1, p2)` | YYMM/YYYYMM arithmetic |
 
 ```
-source=otel-v1-apm-span-* | where startTime > DATE_SUB(NOW(), INTERVAL 1 HOUR)
+source=otel-v1-apm-span-* | where startTime > DATE_SUB(NOW(), INTERVAL 1 HOUR) | stats count() as recent_spans by serviceName
 ```
 
 ### String
@@ -362,6 +434,10 @@ source=otel-v1-apm-span-* | where startTime > DATE_SUB(NOW(), INTERVAL 1 HOUR)
 | `field(s, v1, ...)`, `find_in_set(s, list)` | Position in list |
 | `insert(s, pos, len, new)` | Insert |
 
+```
+source=logs-otel-v1-* | eval body_lower = lower(body) | where body_lower like '%exception%' | eval short_body = left(body, 200) | fields traceId, severityText, short_body | head 10
+```
+
 ### Math
 
 | Function | Description |
@@ -371,6 +447,10 @@ source=otel-v1-apm-span-* | where startTime > DATE_SUB(NOW(), INTERVAL 1 HOUR)
 | `mod(a, b)`, `conv(v, from, to)`, `crc32` | Misc |
 | `sin`, `cos`, `tan`, `asin`, `acos`, `atan`, `atan2(y, x)`, `cot` | Trig |
 | `degrees(r)`, `radians(d)`, `pi()`, `e()`, `rand([seed])` | Constants / conversion |
+
+```
+source=otel-v1-apm-span-* | eval duration_ms = round(durationInNanos / 1000000.0, 2) | where duration_ms > 0 | fields traceId, serviceName, duration_ms | sort - duration_ms | head 10
+```
 
 ### Collection / Multi-Value
 
@@ -382,6 +462,10 @@ source=otel-v1-apm-span-* | where startTime > DATE_SUB(NOW(), INTERVAL 1 HOUR)
 | `mvdedup(f)`, `mvsort(f)`, `mvfilter(expr)` | Transform |
 | `mvrange(start, end, step)` | Generate |
 
+```
+source=otel-v1-apm-span-* | eval tokens = array(`attributes.gen_ai.usage.input_tokens`, `attributes.gen_ai.usage.output_tokens`) | fields traceId, tokens | head 10
+```
+
 ### JSON
 
 | Function | Description |
@@ -389,6 +473,10 @@ source=otel-v1-apm-span-* | where startTime > DATE_SUB(NOW(), INTERVAL 1 HOUR)
 | `json_extract(f, path)`, `json_extract_path_text(f, path)` | Extract |
 | `json_keys(f)`, `json_valid(f)`, `json_array_length(f)` | Inspect |
 | `json_array(v1, ...)`, `json_object(k1, v1, ...)`, `to_json_string(f)` | Construct |
+
+```
+source=otel-v1-apm-span-* | where json_valid(`attributes.gen_ai.tool.call.arguments`) | eval tool_args = json_extract(`attributes.gen_ai.tool.call.arguments`, '$') | fields traceId, `attributes.gen_ai.tool.name`, tool_args | head 10
+```
 
 ### Crypto / IP / System
 
@@ -398,6 +486,11 @@ source=otel-v1-apm-span-* | where startTime > DATE_SUB(NOW(), INTERVAL 1 HOUR)
 | `cidrmatch(ip, 'cidr')` | CIDR range check |
 | `geoip(ip)` | Geo lookup (country, region, city, lat/lon) |
 | `typeof(f)` | Data type of value |
+
+```
+source=otel-v1-apm-span-* | eval trace_hash = md5(traceId) | fields traceId, trace_hash | head 5
+source=otel-v1-apm-span-* | eval type_of_duration = typeof(durationInNanos) | fields traceId, durationInNanos, type_of_duration | head 5
+```
 
 ### Relevance (Full-Text Search)
 
@@ -411,7 +504,7 @@ source=otel-v1-apm-span-* | where startTime > DATE_SUB(NOW(), INTERVAL 1 HOUR)
 | `highlight(f)`, `score(rf)`, `scorequery(rf)` | Highlighting / scoring |
 
 ```
-source=logs-otel-v1-* | where match(body, 'timeout error')
+source=logs-otel-v1-* | where match(body, 'timeout error') | fields traceId, severityText, body | head 10
 ```
 
 ### Expressions / Operators
@@ -419,6 +512,10 @@ source=logs-otel-v1-* | where match(body, 'timeout error')
 - **Arithmetic**: `+`, `-`, `*`, `/`
 - **Comparison**: `=`, `!=` or `<>`, `<`, `>`, `<=`, `>=`
 - **Logical**: `AND`, `OR`, `NOT`, `XOR`
+
+```
+source=otel-v1-apm-span-* | eval duration_ms = durationInNanos / 1000000, total_tokens = `attributes.gen_ai.usage.input_tokens` + `attributes.gen_ai.usage.output_tokens` | where duration_ms > 1000 AND total_tokens > 0 | fields traceId, serviceName, duration_ms, total_tokens | head 10
+```
 
 ---
 

--- a/src/agents/default_agent.py
+++ b/src/agents/default_agent.py
@@ -20,6 +20,26 @@ from utils.obo_context import OboAuth
 
 logger = get_logger(__name__)
 
+
+class LoggingAgentSkills(AgentSkills):
+    """AgentSkills plugin that logs skill activations at INFO level.
+
+    The vended strands plugin logs activations at DEBUG only. This subclass
+    emits a structured INFO event whenever the LLM invokes a skill, so
+    auto-selection is visible in standard logs without enabling DEBUG
+    globally.
+    """
+
+    def _track_activated_skill(self, agent: Agent, skill_name: str) -> None:
+        log_info_event(
+            logger,
+            f"Skill activated by agent: {skill_name}",
+            "default_agent.skill_activated",
+            skill_name=skill_name,
+        )
+        super()._track_activated_skill(agent, skill_name)
+
+
 DEFAULT_SYSTEM_PROMPT = """You are a helpful OpenSearch assistant. You help users understand
 and manage their OpenSearch clusters.
 
@@ -142,7 +162,7 @@ def create_default_agent(opensearch_url: str) -> Agent:
     # Prepare plugins list with AgentSkills if skills are available
     plugins = []
     if skills:
-        agent_skills_plugin = AgentSkills(skills=skills)
+        agent_skills_plugin = LoggingAgentSkills(skills=skills)
         plugins.append(agent_skills_plugin)
         log_info_event(
             logger,

--- a/src/agents/default_agent.py
+++ b/src/agents/default_agent.py
@@ -7,10 +7,11 @@ Handles general queries when no specialized sub-agent matches the page context.
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 import httpx
 from mcp.client.streamable_http import streamable_http_client
-from strands import Agent
+from strands import Agent, AgentSkills, Skill
 from strands.tools.mcp import MCPClient
 
 from server.constants import DEFAULT_MCP_SERVER_URL
@@ -29,20 +30,78 @@ You have access to OpenSearch tools via the MCP Server. Use them to answer quest
 - Cluster settings and configuration
 - Node and shard information
 
+You also have access to domain-specific skills that provide reference documentation
+and guidance for specialized tasks. Consult available skills when users need help
+with specific OpenSearch features or query languages.
+
 When answering:
 - Use the available tools to fetch real data from OpenSearch
 - Present results clearly and concisely
 - If a tool call fails, explain what went wrong and suggest alternatives
 - If you don't have the right tool for a request, explain what's available
+- Consult available skills for specialized guidance and reference documentation
 """
 
 
+def _load_all_skills() -> list[Skill]:
+    """Auto-discover and load all skills from the skills directory.
+
+    Scans ``skills/`` at the project root for subdirectories containing
+    a ``SKILL.md`` file. Each valid skill directory is loaded using the
+    Strands SDK ``Skill.from_file()`` method.
+
+    Returns:
+        List of loaded Skill objects. Invalid or missing skills are
+        skipped with a warning log.
+    """
+    project_root = Path(__file__).parent.parent.parent
+    skills_dir = project_root / "skills"
+
+    if not skills_dir.exists():
+        log_info_event(
+            logger,
+            f"Skills directory not found at {skills_dir}, skipping skill loading",
+            "default_agent.skills_dir_not_found",
+            skills_dir=str(skills_dir),
+        )
+        return []
+
+    skills = []
+    for skill_path in sorted(skills_dir.iterdir()):
+        if not skill_path.is_dir() or not (skill_path / "SKILL.md").exists():
+            continue
+        try:
+            skill = Skill.from_file(skill_path)
+            skills.append(skill)
+            log_info_event(
+                logger,
+                f"Loaded skill: {skill.name}",
+                "default_agent.skill_loaded",
+                skill_name=skill.name,
+                skill_path=str(skill_path),
+            )
+        except Exception as e:
+            log_info_event(
+                logger,
+                f"Failed to load skill at {skill_path}: {e}",
+                "default_agent.skill_load_failed",
+                skill_path=str(skill_path),
+                error=str(e),
+            )
+
+    return skills
+
+
 def create_default_agent(opensearch_url: str) -> Agent:
-    """Create the default agent with all OpenSearch MCP tools.
+    """Create the default agent with all OpenSearch MCP tools and skills.
 
     Connects to the OpenSearch MCP server via Streamable HTTP transport.
     The server URL defaults to ``http://localhost:3001/mcp`` and can be
     overridden with the ``MCP_SERVER_URL`` environment variable.
+
+    Auto-discovers and loads all skills from the ``skills/`` directory.
+    Each subdirectory with a ``SKILL.md`` file is loaded as a skill using
+    the Strands SDK ``AgentSkills`` plugin.
 
     Authentication is handled by :class:`~utils.obo_context.OboAuth`.
     The orchestrator calls ``obo_auth.set_token()`` before each run to
@@ -54,7 +113,7 @@ def create_default_agent(opensearch_url: str) -> Agent:
             server is assumed to already be configured for this cluster).
 
     Returns:
-        Configured Strands Agent with MCP tools.
+        Configured Strands Agent with MCP tools and skills.
     """
     mcp_server_url = os.getenv("MCP_SERVER_URL", DEFAULT_MCP_SERVER_URL)
 
@@ -77,9 +136,27 @@ def create_default_agent(opensearch_url: str) -> Agent:
 
     tools = list(mcp_client.list_tools_sync())
 
+    # Auto-discover and load all skills from skills/ directory
+    skills = _load_all_skills()
+
+    # Prepare plugins list with AgentSkills if skills are available
+    plugins = []
+    if skills:
+        agent_skills_plugin = AgentSkills(skills=skills)
+        plugins.append(agent_skills_plugin)
+        log_info_event(
+            logger,
+            f"Registering {len(skills)} skill(s) with default agent",
+            "default_agent.skills_registered",
+            skill_count=len(skills),
+            skill_names=[s.name for s in skills],
+        )
+
+    # Create agent with MCP tools and skills plugin
     agent = Agent(
         system_prompt=DEFAULT_SYSTEM_PROMPT,
         tools=tools,
+        plugins=plugins,
     )
 
     # Keep references to prevent GC from closing the MCP session and

--- a/tests/unit/test_default_agent.py
+++ b/tests/unit/test_default_agent.py
@@ -1,0 +1,220 @@
+"""Unit tests for the default agent — skill loading and agent construction.
+
+Verifies that:
+1. ``_load_all_skills()`` auto-discovers ``skills/`` directories correctly.
+2. ``create_default_agent()`` wires MCP tools and skills into the strands Agent.
+3. ``LoggingAgentSkills`` emits an INFO-level log on skill activation and
+   still delegates state tracking to the parent class.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from strands import Skill
+
+from agents import default_agent
+from agents.default_agent import (
+    LoggingAgentSkills,
+    _load_all_skills,
+    create_default_agent,
+)
+
+pytestmark = pytest.mark.unit
+
+# Skills expected to ship in the repo's ``skills/`` directory.
+# Append a new entry here when adding a new skill — both the real-repo
+# discovery test and the plugin-wiring test will cover it automatically.
+EXPECTED_REPO_SKILLS = ["ppl-reference"]
+
+
+def _write_skill(skill_dir: Path, name: str, description: str) -> None:
+    """Create a minimal valid SKILL.md under ``skill_dir``."""
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {description}\n---\n\n# Body\nContent\n"
+    )
+
+
+@pytest.fixture
+def fake_project_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect ``_load_all_skills`` to a tmp project root.
+
+    ``_load_all_skills`` resolves ``skills/`` relative to
+    ``default_agent.__file__``. We simulate a project root at ``tmp_path`` by
+    patching that module attribute to a synthetic path three levels deep.
+    """
+    fake_file = tmp_path / "src" / "agents" / "default_agent.py"
+    fake_file.parent.mkdir(parents=True, exist_ok=True)
+    fake_file.touch()
+    monkeypatch.setattr(default_agent, "__file__", str(fake_file))
+    return tmp_path
+
+
+class TestLoadAllSkills:
+    """Group 1 — skill auto-discovery via ``_load_all_skills()``."""
+
+    @pytest.mark.parametrize("expected_name", EXPECTED_REPO_SKILLS)
+    def test_discovers_expected_skill(self, expected_name: str) -> None:
+        """Real repo ``skills/`` dir yields every skill in ``EXPECTED_REPO_SKILLS``."""
+        skills = _load_all_skills()
+
+        names = [s.name for s in skills]
+        assert expected_name in names, (
+            f"expected {expected_name} in loaded skills, got {names}"
+        )
+        skill = next(s for s in skills if s.name == expected_name)
+        assert skill.description, f"{expected_name} has empty description"
+
+    def test_discovers_skills_from_custom_dir(self, fake_project_root: Path) -> None:
+        """Two fake SKILL.md files under ``skills/`` → both are returned."""
+        skills_dir = fake_project_root / "skills"
+        _write_skill(skills_dir / "alpha-skill", "alpha-skill", "First skill")
+        _write_skill(skills_dir / "beta-skill", "beta-skill", "Second skill")
+
+        skills = _load_all_skills()
+
+        names = sorted(s.name for s in skills)
+        assert names == ["alpha-skill", "beta-skill"]
+
+    def test_returns_empty_when_skills_dir_missing(
+        self, fake_project_root: Path
+    ) -> None:
+        """Missing ``skills/`` directory → returns [] without raising."""
+        # fake_project_root has no skills/ subdirectory
+        assert not (fake_project_root / "skills").exists()
+
+        skills = _load_all_skills()
+
+        assert skills == []
+
+    def test_skips_entries_without_skill_md(self, fake_project_root: Path) -> None:
+        """Non-skill entries (loose files, dirs without SKILL.md) are skipped."""
+        skills_dir = fake_project_root / "skills"
+        _write_skill(skills_dir / "valid-skill", "valid-skill", "Real skill")
+        # Directory without SKILL.md
+        (skills_dir / "empty-dir").mkdir()
+        # Stray file directly under skills/
+        (skills_dir / "README.md").write_text("not a skill")
+
+        skills = _load_all_skills()
+
+        assert [s.name for s in skills] == ["valid-skill"]
+
+
+@pytest.fixture
+def mock_mcp_tools() -> list[MagicMock]:
+    """Two synthetic MCP tools."""
+    tool_a = MagicMock()
+    tool_a.tool_name = "list_indices"
+    tool_b = MagicMock()
+    tool_b.tool_name = "search_index"
+    return [tool_a, tool_b]
+
+
+@pytest.fixture
+def patch_mcp(mock_mcp_tools: list[MagicMock]):
+    """Patch MCPClient + streamable_http_client + httpx.AsyncClient.
+
+    Yields the MCPClient class mock so tests can inspect calls if needed.
+    """
+    with (
+        patch("agents.default_agent.MCPClient") as mock_mcp_client_cls,
+        patch("agents.default_agent.streamable_http_client"),
+        patch("agents.default_agent.httpx.AsyncClient"),
+    ):
+        mock_client = MagicMock()
+        mock_client.list_tools_sync.return_value = mock_mcp_tools
+        mock_mcp_client_cls.return_value = mock_client
+        yield mock_mcp_client_cls
+
+
+@pytest.mark.usefixtures("patch_mcp")
+class TestCreateDefaultAgent:
+    """Group 2 — agent construction via ``create_default_agent()``."""
+
+    def test_registers_mcp_tools(self, mock_mcp_tools: list[MagicMock]) -> None:
+        """MCP tools from ``list_tools_sync()`` are forwarded to the strands Agent."""
+        with (
+            patch("agents.default_agent._load_all_skills", return_value=[]),
+            patch("agents.default_agent.Agent") as mock_agent_cls,
+        ):
+            create_default_agent("http://localhost:9200")
+
+        mock_agent_cls.assert_called_once()
+        tools_kwarg = mock_agent_cls.call_args.kwargs["tools"]
+        assert tools_kwarg == mock_mcp_tools
+
+    def test_attaches_logging_agent_skills_plugin(self) -> None:
+        """When skills are discovered, a ``LoggingAgentSkills`` plugin is attached."""
+        fake_skill = Skill(name="fake-skill", description="a fake")
+        with patch("agents.default_agent._load_all_skills", return_value=[fake_skill]):
+            agent = create_default_agent("http://localhost:9200")
+
+        plugins = agent._plugin_registry._plugins
+        assert "agent_skills" in plugins
+        skills_plugin = plugins["agent_skills"]
+        assert isinstance(skills_plugin, LoggingAgentSkills)
+        assert "fake-skill" in skills_plugin._skills
+
+    def test_no_skills_plugin_when_skills_dir_empty(self) -> None:
+        """Zero skills discovered → no ``agent_skills`` plugin attached."""
+        with patch("agents.default_agent._load_all_skills", return_value=[]):
+            agent = create_default_agent("http://localhost:9200")
+
+        assert "agent_skills" not in agent._plugin_registry._plugins
+
+    @pytest.mark.parametrize("expected_name", EXPECTED_REPO_SKILLS)
+    def test_real_skill_registered_in_plugin(self, expected_name: str) -> None:
+        """End-to-end: each expected skill lands inside the ``agent_skills`` plugin."""
+        # Do NOT patch _load_all_skills — let the real function run against the repo.
+        agent = create_default_agent("http://localhost:9200")
+
+        plugins = agent._plugin_registry._plugins
+        assert "agent_skills" in plugins
+        assert expected_name in plugins["agent_skills"]._skills
+
+
+class TestLoggingAgentSkills:
+    """Group 3 — ``LoggingAgentSkills._track_activated_skill`` behavior."""
+
+    def test_activation_logs_at_info_level(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Activation emits exactly one INFO-level record containing the skill name."""
+        plugin = LoggingAgentSkills(
+            skills=[Skill(name="my-skill", description="a skill")]
+        )
+        mock_agent = MagicMock()
+        mock_agent.state.get.return_value = None
+
+        with caplog.at_level(logging.INFO, logger="agents.default_agent"):
+            plugin._track_activated_skill(mock_agent, "my-skill")
+
+        activation_records = [
+            r for r in caplog.records if "Skill activated by agent" in r.message
+        ]
+        assert len(activation_records) == 1
+        record = activation_records[0]
+        assert record.levelno == logging.INFO
+        assert "my-skill" in record.message
+
+    def test_activation_delegates_to_parent(self) -> None:
+        """Parent ``_track_activated_skill`` still runs — state is updated on the agent."""
+        plugin = LoggingAgentSkills(
+            skills=[Skill(name="my-skill", description="a skill")]
+        )
+        mock_agent = MagicMock()
+        # Simulate empty state so parent initializes it.
+        mock_agent.state.get.return_value = None
+
+        plugin._track_activated_skill(mock_agent, "my-skill")
+
+        # Parent calls agent.state.set(state_key, {"activated_skills": [...]})
+        mock_agent.state.set.assert_called_once()
+        call_args = mock_agent.state.set.call_args
+        assert call_args.args[0] == "agent_skills"
+        assert call_args.args[1] == {"activated_skills": ["my-skill"]}


### PR DESCRIPTION
### Description

 - Add `ppl-reference` skill under `skills/` with PPL command syntax, functions, and examples for observability queries                                                
  - Add auto-discovery of skills from `skills/` directory in default agent (`_load_all_skills()`)                                                                       
  - Load skills using Strands `AgentSkills` plugin; update system prompt to mention skill availability                                                                  
  - Subclass `AgentSkills` as `LoggingAgentSkills` so skill activations are visible at **INFO** (vended plugin only emits at DEBUG)                                     
  - Add unit tests in `tests/unit/test_default_agent.py` covering skill discovery, agent construction, and activation logging    
                                                                                                                                                                        