### PR TITLE
Fix: Default agent now respects BEDROCK_INFERENCE_PROFILE_ARN (#94)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Added
 - PPL reference skill and skills auto-discovery for the default agent
 ### Fixed
+- Default agent now respects `BEDROCK_INFERENCE_PROFILE_ARN` env var instead of silently falling back to a hardcoded Sonnet 4 model (fixes #94)
 ### Removed
 
 ## [0.2.0] - 2026-04-10

--- a/src/agents/default_agent.py
+++ b/src/agents/default_agent.py
@@ -9,9 +9,11 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
+import boto3
 import httpx
 from mcp.client.streamable_http import streamable_http_client
 from strands import Agent, AgentSkills, Skill
+from strands.models import BedrockModel
 from strands.tools.mcp import MCPClient
 
 from server.constants import DEFAULT_MCP_SERVER_URL
@@ -19,6 +21,24 @@ from utils.logging_helpers import get_logger, log_info_event
 from utils.obo_context import OboAuth
 
 logger = get_logger(__name__)
+
+# Default Bedrock model — same as Strands SDK default.
+# Used when BEDROCK_INFERENCE_PROFILE_ARN is not explicitly set.
+_DEFAULT_BEDROCK_MODEL_ID = "us.anthropic.claude-sonnet-4-20250514-v1:0"
+
+
+def _get_aws_session() -> boto3.Session:
+    """Create a boto3 session using the default AWS credential provider chain."""
+    return boto3.Session()
+
+
+def _create_default_agent_model(inference_profile_arn: str) -> BedrockModel:
+    """Create a BedrockModel for the default agent."""
+    return BedrockModel(
+        model_id=inference_profile_arn,
+        boto_session=_get_aws_session(),
+        streaming=True,
+    )
 
 
 class LoggingAgentSkills(AgentSkills):
@@ -172,8 +192,22 @@ def create_default_agent(opensearch_url: str) -> Agent:
             skill_names=[s.name for s in skills],
         )
 
+    # Read Bedrock inference profile from env var, falling back to Strands default.
+    # Using a local variable (not os.environ mutation) — the default agent has no
+    # sub-agents that need to observe this fallback.
+    inference_profile_arn = os.getenv(
+        "BEDROCK_INFERENCE_PROFILE_ARN", _DEFAULT_BEDROCK_MODEL_ID
+    )
+    log_info_event(
+        logger,
+        f"Default agent using Bedrock inference profile: {inference_profile_arn}",
+        "default_agent.bedrock_model",
+        inference_profile_arn=inference_profile_arn,
+    )
+
     # Create agent with MCP tools and skills plugin
     agent = Agent(
+        model=_create_default_agent_model(inference_profile_arn),
         system_prompt=DEFAULT_SYSTEM_PROMPT,
         tools=tools,
         plugins=plugins,

--- a/tests/unit/test_default_agent.py
+++ b/tests/unit/test_default_agent.py
@@ -18,6 +18,7 @@ from strands import Skill
 
 from agents import default_agent
 from agents.default_agent import (
+    _DEFAULT_BEDROCK_MODEL_ID,
     LoggingAgentSkills,
     _load_all_skills,
     create_default_agent,
@@ -218,3 +219,55 @@ class TestLoggingAgentSkills:
         call_args = mock_agent.state.set.call_args
         assert call_args.args[0] == "agent_skills"
         assert call_args.args[1] == {"activated_skills": ["my-skill"]}
+
+
+@pytest.mark.usefixtures("patch_mcp")
+class TestDefaultAgentModelSelection:
+    """Group 4 — Bedrock model selection via ``BEDROCK_INFERENCE_PROFILE_ARN``.
+
+    Regression coverage for issue #94: the default agent must respect the
+    ``BEDROCK_INFERENCE_PROFILE_ARN`` env var and fall back to the documented
+    Strands default when it is unset.
+    """
+
+    def test_uses_inference_profile_arn_from_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When ``BEDROCK_INFERENCE_PROFILE_ARN`` is set, the agent uses that ARN."""
+        test_arn = (
+            "arn:aws:bedrock:eu-west-1:123456789012:inference-profile/"
+            "eu.anthropic.claude-haiku-4-5-20251001-v1:0"
+        )
+        monkeypatch.setenv("BEDROCK_INFERENCE_PROFILE_ARN", test_arn)
+
+        with (
+            patch("agents.default_agent._load_all_skills", return_value=[]),
+            patch("agents.default_agent.BedrockModel") as mock_bedrock_cls,
+            patch("agents.default_agent._get_aws_session") as mock_session_fn,
+        ):
+            create_default_agent("http://localhost:9200")
+
+        mock_bedrock_cls.assert_called_once_with(
+            model_id=test_arn,
+            boto_session=mock_session_fn.return_value,
+            streaming=True,
+        )
+
+    def test_falls_back_to_default_when_env_var_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When ``BEDROCK_INFERENCE_PROFILE_ARN`` is unset, falls back to default."""
+        monkeypatch.delenv("BEDROCK_INFERENCE_PROFILE_ARN", raising=False)
+
+        with (
+            patch("agents.default_agent._load_all_skills", return_value=[]),
+            patch("agents.default_agent.BedrockModel") as mock_bedrock_cls,
+            patch("agents.default_agent._get_aws_session") as mock_session_fn,
+        ):
+            create_default_agent("http://localhost:9200")
+
+        mock_bedrock_cls.assert_called_once_with(
+            model_id=_DEFAULT_BEDROCK_MODEL_ID,
+            boto_session=mock_session_fn.return_value,
+            streaming=True,
+        )


### PR DESCRIPTION


### Description
The default agent previously called Agent(...) without a model= kwarg, causing Strands to fall back to a hardcoded us.anthropic.claude-sonnet-4 model regardless of user configuration. This meant users with EU inference profiles or Claude Haiku 4.5 setups got ResourceNotFoundException errors on every chat request.

Mirrors the pattern already used by create_art_agent(): read BEDROCK_INFERENCE_PROFILE_ARN from env, fall back to the Strands default when unset, and pass the resulting BedrockModel to Agent(model=...).

Deliberately deviates from ART by using a local variable instead of mutating os.environ — the default agent has no sub-agents that need to read the fallback via environment.

Adds regression tests covering both the env-set and env-unset paths, using the exact ARN from the bug report.

### Issues Resolved
Closes [#94]


