### PR TITLE
Tune PPL skill activation via system prompt and description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Added
 - PPL reference skill and skills auto-discovery for the default agent
 ### Fixed
+- Default agent now reliably activates the `ppl-reference` skill before calling query-language tools, via a tool-coupled rule in the system prompt
 ### Removed
 
 ## [0.2.0] - 2026-04-10

--- a/skills/ppl-reference/SKILL.md
+++ b/skills/ppl-reference/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ppl-reference
-description: Comprehensive PPL (Piped Processing Language) reference for OpenSearch with command syntax, functions, and examples for observability queries.
+description: Use when the user asks to write, generate, fix, explain, or validate a PPL query, or mentions PPL, Piped Processing Language, observability queries, or OpenSearch log/trace/span queries.
 ---
 
 # PPL Language Reference

--- a/src/agents/default_agent.py
+++ b/src/agents/default_agent.py
@@ -50,9 +50,16 @@ You have access to OpenSearch tools via the MCP Server. Use them to answer quest
 - Cluster settings and configuration
 - Node and shard information
 
-You also have access to domain-specific skills that provide reference documentation
-and guidance for specialized tasks. Consult available skills when users need help
-with specific OpenSearch features or query languages.
+You also have access to domain-specific skills listed in <available_skills>.
+Each skill's description states when to use it.
+
+The Dashboards UI lets users pick a query language (PPL, SQL, DSL, etc.).
+Respect the user's selection — use whichever language the context implies, do
+not override their choice. Before calling any tool that runs a query language
+(such as PPL, SQL, or DSL), first look in <available_skills> for a matching
+reference skill and activate it via the `skills` tool. Your training knowledge
+of these query languages is often wrong or outdated — the skill contains the
+authoritative syntax.
 
 When answering:
 - Use the available tools to fetch real data from OpenSearch


### PR DESCRIPTION

### Description
The ppl-reference skill wasn't reliably activating on PPL-related prompts. The LLM would skip straight to execute_ppl_query using its training knowledge. Description wording alone (even ALL CAPS directives) proved insufficient; the LLM consistently rationalized activation as unnecessary when it thought it already knew the answer.

Fix combines two changes:
- System prompt adds a generic clause: before calling any tool that executes a query in a domain-specific language, look in <available_skills> for a matching reference skill and activate it. This scales to future SQL/DSL/other-language skills without further prompt edits.
- Skill description narrowed to pure trigger conditions. 

