### PR TITLE
docs: address README gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ OpenSearch Agent Server enables intelligent agent-based interactions within Open
 - **Multi-Agent Orchestration** — Routes requests to specialized agents based on context
 - **OpenSearch Integration** — Connects to OpenSearch via MCP for real-time data access
 - **AG-UI Protocol** — Implements OpenSearch Dashboard's agent UI protocol with SSE streaming
-- **Flexible LLM Support** — Works with AWS Bedrock, Ollama, or other LLM providers
+- **LLM Support** — AWS Bedrock today; Ollama support in progress
 - **Production Ready** — Includes authentication, rate limiting, error recovery, and observability
 
 ## Demo
@@ -43,91 +43,35 @@ OpenSearch Dashboards (AG-UI)
 ## Prerequisites
 
 - **Python 3.12+**
-- **OpenSearch 2.x** (local or remote cluster)
-- **LLM Provider** (choose one):
-  - AWS Bedrock (requires AWS credentials)
-  - Ollama (local installation)
+- **OpenSearch 2.x or 3.x** (local or remote cluster)
+- **AWS Bedrock** with access to a Claude inference profile.
+- **For Dashboards integration**: OpenSearch Dashboards **≥ 3.6**, matched to your OpenSearch major version. Matching exact versions avoids edge cases.
 
-## Installation
+## Get Started
 
-1. **Clone the repository**
-   ```bash
-   git clone https://github.com/opensearch-project/opensearch-agent-server.git
-   cd opensearch-agent-server
-   ```
+Pick the path that matches your situation:
 
-2. **Create virtual environment**
-   ```bash
-   python -m venv .venv
-   source .venv/bin/activate  # On Windows: .venv\Scripts\activate
-   ```
+| You want to... | Use this section |
+|---|---|
+| Run the agent server against an existing OpenSearch cluster | [Option A — Install from PyPI](#option-a--install-from-pypi) |
+| See everything (OS + OSD + agent + demo data) running end-to-end | [Option B — Full demo quickstart](#option-b--full-demo-quickstart) |
+| Hack on this repository's source code | [Option C — Run from source](#option-c--run-from-source) |
 
-3. **Install dependencies**
-   ```bash
-   pip install -e .
-   ```
+### Option A — Install from PyPI
 
-4. **Configure environment**
-   ```bash
-   cp .env.example .env
-   # Edit .env with your configuration
-   ```
-
-## Configuration
-
-Create a `.env` file with the following settings:
-
-```bash
-# OpenSearch Connection
-OPENSEARCH_URL=https://localhost:9200
-OPENSEARCH_USERNAME=admin
-OPENSEARCH_PASSWORD=admin
-
-# Authentication (set to false for local development)
-AG_UI_AUTH_ENABLED=false
-
-# CORS (allow OpenSearch Dashboards origin)
-AG_UI_CORS_ORIGINS=http://localhost:5601
-
-# LLM Provider — Option 1: AWS Bedrock
-AWS_ACCESS_KEY_ID=your_access_key
-AWS_SECRET_ACCESS_KEY=your_secret_key
-AWS_REGION=us-east-1
-BEDROCK_INFERENCE_PROFILE_ARN=arn:aws:bedrock:...
-
-# LLM Provider — Option 2: Ollama (local)
-OLLAMA_MODEL=llama3
-
-# Logging
-AG_UI_LOG_FORMAT=human
-AG_UI_LOG_LEVEL=INFO
-```
-
-## Quick Start
-
-```bash
-./scripts/quickstart.sh
-```
-
-This clones, builds, and starts everything in one command:
-
-1. Clones [search-relevance](https://github.com/opensearch-project/search-relevance) and [OpenSearch Dashboards](https://github.com/opensearch-project/OpenSearch-Dashboards) (with the [dashboards-search-relevance](https://github.com/opensearch-project/dashboards-search-relevance) plugin)
-2. Bootstraps OSD and starts OpenSearch via `./gradlew run`
-3. Starts MCP Server (port 3001), OSD (port 5601), and Agent Server (port 8001)
-4. Creates a workspace with a local data source and loads demo data
-5. Runs a smoke test against all services
-
-**Prerequisites:** Java 21+, Node.js 20+, Python 3.12+, [uv](https://astral.sh/uv), yarn, jq, curl
-
-**Access the Chat:** Open http://localhost:5601 and click the chat icon in the header.
-
-## PyPI Installation
-
-If you already have an OpenSearch cluster running and don't need the full quickstart setup, you can install and run the agent server directly from PyPI:
+If you already have an OpenSearch cluster running and don't need the full quickstart setup, install the agent server directly from PyPI:
 
 ```bash
 pip install opensearch-agent-server
 ```
+
+> **Note:** the `opensearch-agent-server` CLI entry point is available in **v0.2.1 and later**. If `pip install` currently gives you v0.2.0, the command below will not be installed. Until v0.2.1 is published to PyPI, install from the `main` branch instead:
+>
+> ```bash
+> pip install git+https://github.com/opensearch-project/opensearch-agent-server.git
+> ```
+>
+> Verify with `pip show opensearch-agent-server | grep Version`.
 
 Configure your environment:
 
@@ -136,6 +80,8 @@ export OPENSEARCH_URL=https://localhost:9200
 export OPENSEARCH_USERNAME=admin
 export OPENSEARCH_PASSWORD=admin
 export AG_UI_AUTH_ENABLED=false
+export AWS_REGION=us-east-1
+export BEDROCK_INFERENCE_PROFILE_ARN=arn:aws:bedrock:...
 ```
 
 Start the agent server and MCP server together:
@@ -158,64 +104,191 @@ You can also customize the MCP server port and config:
 opensearch-agent-server --with-mcp --mcp-port 3002 --mcp-config ./custom_mcp.yml
 ```
 
-### Manual Setup
+### Option B — Full demo quickstart
 
-To run each component separately:
-
-**Terminal 1 - OpenSearch**
 ```bash
-# Start OpenSearch on port 9200
-docker run -d -p 9200:9200 -p 9600:9600 \
-  -e "discovery.type=single-node" \
-  -e "OPENSEARCH_INITIAL_ADMIN_PASSWORD=Admin1234!" \
-  opensearchproject/opensearch:latest
-
-# Verify
-curl http://localhost:9200 -u admin:Admin1234!
+./scripts/quickstart.sh
 ```
 
-**Terminal 2 - Agent Server**
-```bash
-cd opensearch-agent-server
-cp .env.example .env
-# Edit .env with your settings
-source .venv/bin/activate
-python run_server.py
+This clones, builds, and starts everything in one command:
 
-# Server starts on http://localhost:8001
+1. Clones [search-relevance](https://github.com/opensearch-project/search-relevance) and [OpenSearch Dashboards](https://github.com/opensearch-project/OpenSearch-Dashboards) (with the [dashboards-search-relevance](https://github.com/opensearch-project/dashboards-search-relevance) plugin)
+2. Bootstraps OSD and starts OpenSearch via `./gradlew run`
+3. Starts MCP Server (port 3001), OSD (port 5601), and Agent Server (port 8001)
+4. Creates a workspace with a local data source and loads demo data
+5. Runs a smoke test against all services
+
+**Additional prerequisites for this path:** Java 21+, Node.js 20+, [uv](https://astral.sh/uv), yarn, jq, curl.
+
+**Access the Chat:** Open http://localhost:5601 and click the chat icon in the header.
+
+### Option C — Run from source
+
+Use this path if you're contributing to this repository or want to modify the agent server itself. You'll need a running OpenSearch cluster and MCP server — see [Option B](#option-b--full-demo-quickstart) for a one-command setup.
+
+1. **Clone the repository**
+   ```bash
+   git clone https://github.com/opensearch-project/opensearch-agent-server.git
+   cd opensearch-agent-server
+   ```
+
+2. **Create virtual environment**
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate  # On Windows: .venv\Scripts\activate
+   ```
+
+3. **Install in editable mode**
+   ```bash
+   pip install -e .
+   ```
+
+4. **Configure environment**
+   ```bash
+   cp .env.example .env
+   # Edit .env with your configuration
+   ```
+
+5. **Start the server**
+   ```bash
+   python run_server.py
+   ```
+
+## Integration with OpenSearch Dashboards
+
+The agent server works with any install path above. Configure OSD once (version **≥ 3.6** required), then point it at the running agent server.
+
+### Authentication flow
+
+```
+Browser (logged-in user)
+  │
+  │ 1. Session (basic / SAML / OIDC)
+  ▼
+OpenSearch Dashboards (>= 3.6)
+  │
+  │ 2. POST /api/chat/proxy
+  │    ┌─────────────────────────────────────────────┐
+  │    │ chat.forwardCredentials: true               │
+  │    │   → mint OBO token via /_plugins/_security  │
+  │    │     /api/obo/token                          │
+  │    │   → add "Authorization: Bearer <token>"     │
+  │    │   (if OBO is unavailable at runtime, OSD    │
+  │    │    logs "OBO token generation unavailable"  │
+  │    │    and falls through with no header)        │
+  │    │ chat.forwardCredentials: false (default)    │
+  │    │   → no Authorization header                 │
+  │    └─────────────────────────────────────────────┘
+  ▼
+Agent Server /runs
+  │
+  │ 3. Stores incoming Bearer token on OboAuth
+  │    (thread-safe, per-request).
+  │
+  │ 4. Agent calls MCP tool
+  │    httpx replays "Authorization: Bearer <token>"
+  │    on every outgoing request (OboAuth.async_auth_flow).
+  │    If no token was received, no Authorization header
+  │    is added.
+  ▼
+MCP Server (OPENSEARCH_HEADER_AUTH=true)
+  │
+  │ 5. If Authorization Bearer is present: use it.
+  │    Otherwise: fall back to OPENSEARCH_USERNAME /
+  │    OPENSEARCH_PASSWORD env vars (MCP's own config).
+  ▼
+OpenSearch Cluster
+  │
+  └─ Identity enforcement:
+     • OBO token → logged-in Dashboards user
+       (row-level / field-level security applied)
+     • No token → MCP service account
+       (all users share one identity)
 ```
 
-**Terminal 3 - OpenSearch Dashboards**
+Edit `config/opensearch_dashboards.yml`:
+
+```yaml
+# OpenSearch connection
+opensearch.hosts: ["http://localhost:9200"]
+opensearch.ssl.verificationMode: none
+
+# Required for the chat button to appear in the top-right header.
+uiSettings:
+  overrides:
+    "home:useNewHomePage": true
+
+# Sends current page context (app ID, filters, queries) to the agent.
+contextProvider:
+  enabled: true
+
+# Chat -> agent server wiring.
+chat:
+  enabled: true
+  agUiUrl: "http://localhost:8001/runs"
+  # Forward the logged-in user's identity to the agent server via an
+  # On-Behalf-Of token. Requires the OpenSearch security plugin with
+  # OBO enabled (/_plugins/_security/api/obo/token). Leave false if
+  # security is disabled; see "Credential forwarding" below.
+  # forwardCredentials: true
+
+# Workspaces (required for the agent's per-workspace data source routing).
+# NOTE: workspaces are incompatible with the security plugin's multi-tenancy
+# feature. If your cluster has opensearch_security.multitenancy.enabled=true,
+# set it to false in opensearch.yml before enabling workspaces.
+workspace.enabled: true
+data_source.enabled: true
+data_source.hideLocalCluster: false
+```
+
+**Start OpenSearch Dashboards:**
+
 ```bash
 cd OpenSearch-Dashboards
-# Ensure config/opensearch_dashboards.yml has chat.agUiUrl configured
 yarn start --no-base-path
-
-# Dashboard opens on http://localhost:5601
 ```
 
-**Access the Chat**
+**Access the chat interface:**
+
 - Open http://localhost:5601
 - Click the chat icon in the top-right header
-- Start asking questions about your data!
+- Start chatting with your data
+
+## Configuration
+
+The full list of configuration keys is in `.env.example`. The most common ones:
+
+```bash
+# OpenSearch Connection
+OPENSEARCH_URL=https://localhost:9200
+OPENSEARCH_USERNAME=admin
+OPENSEARCH_PASSWORD=admin
+
+# Authentication (set to false for local development)
+AG_UI_AUTH_ENABLED=false
+
+# CORS (allow OpenSearch Dashboards origin)
+AG_UI_CORS_ORIGINS=http://localhost:5601
+
+# LLM Provider — AWS Bedrock (currently required)
+AWS_ACCESS_KEY_ID=your_access_key
+AWS_SECRET_ACCESS_KEY=your_secret_key
+AWS_REGION=us-east-1
+BEDROCK_INFERENCE_PROFILE_ARN=arn:aws:bedrock:...
+
+# Ollama support is in progress and not yet wired up.
+# OLLAMA_MODEL=llama3
+
+# Logging
+AG_UI_LOG_FORMAT=human
+AG_UI_LOG_LEVEL=INFO
+```
+
+> `.env.example` is the authoritative source of configuration keys. The snippet above shows the common ones; see `.env.example` in the repo for the full list.
 
 ## Usage
 
-### Start the Server
-
-```bash
-python run_server.py
-```
-
-Or using uvicorn directly:
-
-```bash
-uvicorn server.ag_ui_app:app --host 0.0.0.0 --port 8001
-```
-
-The server will start on `http://localhost:8001`
-
-### Verify Installation
+### Verify the server is running
 
 ```bash
 # Check server health
@@ -233,65 +306,125 @@ curl -X POST http://localhost:8001/runs \
   }'
 ```
 
-### Integration with OpenSearch Dashboards
+### Start options
 
-1. **Start OpenSearch** (port 9200)
-   ```bash
-   # Using Docker
-   docker run -d -p 9200:9200 -p 9600:9600 \
-     -e "discovery.type=single-node" \
-     -e "OPENSEARCH_INITIAL_ADMIN_PASSWORD=Admin1234!" \
-     opensearchproject/opensearch:latest
+```bash
+# Via the PyPI CLI (Option A)
+opensearch-agent-server --with-mcp
 
-   # Or use your local OpenSearch installation
-   ```
+# Via the source entry point (Option C)
+python run_server.py
 
-2. **Start OpenSearch Agent Server** (port 8001)
-   ```bash
-   cd opensearch-agent-server
-   source .venv/bin/activate
-   python run_server.py
-   ```
+# Or with uvicorn directly
+uvicorn server.ag_ui_app:app --host 0.0.0.0 --port 8001
+```
 
-3. **Configure OpenSearch Dashboards**
+The server listens on `http://localhost:8001`.
 
-   Edit `config/opensearch_dashboards.yml`:
+## API Endpoints
 
-   ```yaml
-   # OpenSearch connection
-   opensearch.hosts: ["http://localhost:9200"]
-   opensearch.ssl.verificationMode: none
+### Health Check
+```
+GET /health
+```
+Returns server health status.
 
-   # Enable new UI header (required for chat button)
-   uiSettings:
-     overrides:
-       "home:useNewHomePage": true
+### List Agents
+```
+GET /agents
+```
+Returns available agents and their capabilities.
 
-   # Enable context provider (sends page context to agent)
-   contextProvider:
-     enabled: true
+### Create Run (AG-UI Protocol)
+```
+POST /runs
+```
+Creates a new agent run with streaming responses via SSE.
 
-   # Enable chat with opensearch agent server
-   chat:
-     enabled: true
-     agUiUrl: "http://localhost:8001/runs"
-   ```
+### Get Run Status
+```
+GET /runs/{run_id}
+```
+Returns the status of a specific run.
 
-4. **Start OpenSearch Dashboards** (port 5601)
-   ```bash
-   cd OpenSearch-Dashboards
-   yarn start --no-base-path
-   ```
+## Troubleshooting
 
-5. **Access the Chat Interface**
-   - Open http://localhost:5601 in your browser
-   - Look for the chat icon in the top-right header
-   - Click to open the assistant panel
-   - Start chatting with your data!
+### `command not found: opensearch-agent-server` after `pip install`
+
+The CLI entry point was added in **v0.2.1**. The current PyPI release is v0.2.0, which does not install this command. Until v0.2.1 is published, install from `main` instead:
+
+```bash
+pip install git+https://github.com/opensearch-project/opensearch-agent-server.git
+```
+
+### Chat icon doesn't appear in the OSD header
+
+The chat button only renders when the new UI header is enabled:
+
+```yaml
+uiSettings:
+  overrides:
+    "home:useNewHomePage": true
+```
+
+Also confirm you're on OSD **≥ 3.6**; earlier versions ship an experimental chat plugin that doesn't integrate with this agent server.
+
+### Workspaces don't work
+
+Workspaces are incompatible with the security plugin's multi-tenancy feature. In your OpenSearch `opensearch.yml`:
+
+```yaml
+opensearch_security.multitenancy.enabled: false
+```
+
+Then restart OpenSearch. (Documented in OSD's own [explore plugin README](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/src/plugins/explore/README.md).)
+
+### Agent says UBI data is unavailable
+
+The ART agent's user-behavior-analysis sub-agent requires `ubi_queries` and `ubi_events` indices from the [UBI plugin](https://docs.opensearch.org/latest/search-plugins/ubi/). Without them, the agent reports that UBI data is unavailable and falls back to LLM-generated judgment lists for evaluation — other ART features (hypothesis generation, pairwise experiments, search configurations) still work.
+
+**Symptom to watch for:** the LLM may present an empty MCP tool result as a `502 Bad Gateway` message even though the underlying MCP call returned 200. If you don't need UBI features, use the **default agent** instead of the ART agent.
+
+### OSD crashes with `Socket timeout` during long Bedrock calls
+
+OSD's HTTP keepalive can terminate the connection while a sub-agent is still running against Bedrock, producing:
+
+```
+Error: Socket timeout
+    at TLSSocket.onTimeout (.../agentkeepalive/lib/agent.js:350:23)
+```
+
+Raise the OSD-side timeouts in `opensearch_dashboards.yml`:
+
+```yaml
+opensearch.requestTimeout: 300000    # 5 min
+opensearch.pingTimeout: 30000        # 30 s
+```
+
+Also consider running OSD under a process supervisor so it recovers automatically if it does crash.
+
+### OpenSearch Connection Issues
+
+- Verify OpenSearch is running: `curl http://localhost:9200`
+- Check credentials in `.env`
+- Disable SSL verification for local development. Note: data source SSL is a *separate* setting from cluster SSL; disabling `opensearch.ssl.verificationMode` does not automatically apply to data sources added via the workspace data-source UI.
+
+### LLM Provider Issues
+
+- **AWS Bedrock**: Ensure `AWS_REGION` and `BEDROCK_INFERENCE_PROFILE_ARN` are set, or that `AWS_PROFILE`/`AWS_ACCESS_KEY_ID` credentials are valid. The agent server does not start a fallback LLM if Bedrock is unreachable; you'll see errors on the first agent request.
+
+### Port Conflicts
+
+If port 8001 is in use, modify the startup command:
+```bash
+uvicorn server.ag_ui_app:app --host 0.0.0.0 --port 8002
+```
 
 ## Development
 
 ### Install Development Dependencies
+
+Assumes you've already completed [Option C — Run from source](#option-c--run-from-source). Add the test/lint extras:
 
 ```bash
 pip install -e ".[dev]"
@@ -348,52 +481,6 @@ opensearch-agent-server/
 └── .env.example                   # Environment template
 ```
 
-## API Endpoints
-
-### Health Check
-```
-GET /health
-```
-Returns server health status.
-
-### List Agents
-```
-GET /agents
-```
-Returns available agents and their capabilities.
-
-### Create Run (AG-UI Protocol)
-```
-POST /runs
-```
-Creates a new agent run with streaming responses via SSE.
-
-### Get Run Status
-```
-GET /runs/{run_id}
-```
-Returns the status of a specific run.
-
-## Troubleshooting
-
-### OpenSearch Connection Issues
-
-- Verify OpenSearch is running: `curl http://localhost:9200`
-- Check credentials in `.env`
-- Disable SSL verification for local development
-
-### LLM Provider Issues
-
-- **AWS Bedrock**: Ensure AWS credentials are configured
-- **Ollama**: Verify Ollama is running: `ollama list`
-
-### Port Conflicts
-
-If port 8001 is in use, modify the startup command:
-```bash
-uvicorn server.ag_ui_app:app --host 0.0.0.0 --port 8002
-```
-
 ## Contributing
 
 Contributions are welcome! Please:
@@ -410,6 +497,6 @@ This project is licensed under the Apache License 2.0 - see the LICENSE file for
 
 ## Acknowledgments
 
-- Built with [strands-agents](https://github.com/anthropics/strands-agents) for multi-agent orchestration
+- Built with [strands-agents](https://github.com/strands-agents/sdk-python) for multi-agent orchestration
 - Implements [AG-UI Protocol](https://github.com/opensearch-project/ag-ui-protocol) for OpenSearch Dashboards
 - Uses [Model Context Protocol (MCP)](https://github.com/modelcontextprotocol) for OpenSearch integration


### PR DESCRIPTION


### Description
Content 
-------------------------------
1. LLM provider claim — Bedrock is currently required; Ollama support is in progress but not yet wired up.
2. OpenSearch Dashboards minimum version — >= 3.6, matched to the OpenSearch major version.
3. Workspaces + multi-tenancy conflict — documented in OSD's own src/plugins/explore/README.md; surface the workaround.
4. ART without UBI indices — the agent degrades gracefully rather than crashing; document what actually happens, including the "502 Bad Gateway" symptom.
5. agentkeepalive socket-timeout crash on long Bedrock calls — document the OSD-side requestTimeout / pingTimeout workaround.
6. CLI command-not-found after pip install — v0.2.1 CLI is not on PyPI yet; suggest git install as workaround.

Structure
---------
- Reorder top-level sections so reading top-to-bottom follows user intent: Prerequisites -> Get Started (three numbered install options) -> OSD integration -> Configuration -> Usage -> API -> Troubleshooting -> Development.
- Move "Install from source" to Option C so casual users aren't directed to `pip install -e .` by default.
- Add a decision table at the top of "Get Started" so users pick the right install path.
- Call out that Option B is the full demo stack (OS + OSD + MCP + agent), not just a dependency bootstrap.

OpenSearch Dashboards integration
---------------------------------
- Add an authentication-flow diagram showing exactly which identity reaches OpenSearch under each configuration (forwardCredentials on/off, OBO configured or not). Verified against obo_context.py, agent_orchestrator.py, and the MCP server's opensearch/client.py.
- Expand the OSD config snippet with the full set of required settings (workspaces, data_source, forwardCredentials).

Cleanups
--------
- Fix strands-agents link in Acknowledgments (strands-agents/sdk-python, not anthropics/strands-agents).

### Issues Resolved
Closes [#105]

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
