### PR TITLE
Add OSS  Readiness Files and Dev Guide

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,22 @@
+This code of conduct applies to all spaces provided by the OpenSearch project including in code, documentation, issue trackers, mailing lists, chat channels, wikis, blogs, social media and any other communication channels used by the project.
+
+**Our open source communities endeavor to:**
+
+* Be Inclusive: We are committed to being a community where everyone can join and contribute. This means using inclusive and welcoming language.
+* Be Welcoming: We are committed to maintaining a safe space for everyone to be able to contribute.
+* Be Respectful: We are committed to encouraging differing viewpoints, accepting constructive criticism and work collaboratively towards decisions that help the project grow. Disrespectful and unacceptable behavior will not be tolerated.
+* Be Collaborative: We are committed to supporting what is best for our community and users. When we build anything for the benefit of the project, we should document the work we do and communicate to others on how this affects their work.
+
+**Our Responsibility. As contributors, members, or bystanders we each individually have the responsibility to behave professionally and respectfully at all times. Disrespectful and unacceptable behaviors include, but are not limited to:**
+
+* The use of violent threats, abusive, discriminatory, or derogatory language;
+* Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental illness, race, political or religious affiliation;
+* Posting of sexually explicit or violent content;
+* The use of sexualized language and unwelcome sexual attention or advances;
+* Public or private harassment of any kind;
+* Publishing private information, such as physical or electronic address, without permission;
+* Other conduct which could reasonably be considered inappropriate in a professional setting;
+* Advocating for or encouraging any of the above behaviors.
+* Enforcement and Reporting Code of Conduct Issues:
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported. [Contact us](mailto:opensource-codeofconduct@amazon.com). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,92 @@
+- [Contributing to OpenSearch Agent Server](#contributing-to-opensearch-agent-server)
+- [First Things First](#first-things-first)
+- [Ways to Contribute](#ways-to-contribute)
+  - [Bug Reports](#bug-reports)
+  - [Feature Requests](#feature-requests)
+  - [Contributing Code](#contributing-code)
+- [Developer Certificate of Origin](#developer-certificate-of-origin)
+- [Review Process](#review-process)
+
+## Contributing to OpenSearch Agent Server
+
+OpenSearch is a community project that is built and maintained by people just like **you**. We're glad you're interested in helping out. There are several different ways you can do it, but before we talk about that, let's talk about how to get started.
+
+For local setup, running the server, code style, testing, and adding new agents, see the [Developer Guide](DEVELOPER_GUIDE.md).
+
+## First Things First
+
+1. **When in doubt, open an issue** - For almost any type of contribution, the first step is opening an issue. Even if you think you already know what the solution is, writing down a description of the problem you're trying to solve will help everyone get context when they review your pull request. If it's truly a trivial change (e.g. spelling error), you can skip this step -- but as the subject says, when in doubt, [open an issue](https://github.com/opensearch-project/opensearch-agent-server/issues/new/choose).
+
+2. **Only submit your own work** (or work you have sufficient rights to submit) - Please make sure that any code or documentation you submit is your work or you have the rights to submit. We respect the intellectual property rights of others, and as part of contributing, we'll ask you to sign your contribution with a "Developer Certificate of Origin" (DCO) that states you have the rights to submit this work and you understand we'll use your contribution. There's more information about this topic in the [DCO section](#developer-certificate-of-origin).
+
+## Ways to Contribute
+
+### Bug Reports
+
+Ugh! Bugs!
+
+A bug is when software behaves in a way that you didn't expect and the developer didn't intend. To help us understand what's going on, we first want to make sure you're working from the latest version.
+
+Once you've confirmed that the bug still exists in the latest version, you'll want to check to make sure it's not something we already know about on the [open issues GitHub page](https://github.com/opensearch-project/opensearch-agent-server/issues).
+
+If you've upgraded to the latest version and you can't find it in our open issues list, then you'll need to tell us how to reproduce it. Provide as much information as you can. You may think that the problem lies with your query, when actually it depends on how your data is indexed. The easier it is for us to recreate your problem, the faster it is likely to be fixed.
+
+### Feature Requests
+
+If you've thought of a way that OpenSearch Agent Server could be better, we want to hear about it. We track feature requests using GitHub, so please feel free to open an issue which describes the feature you would like to see, why you need it, and how it should work.
+
+### Contributing Code
+
+As with other types of contributions, the first step is to [open an issue on GitHub](https://github.com/opensearch-project/opensearch-agent-server/issues/new/choose). Opening an issue before you make changes makes sure that someone else isn't already working on that particular problem. It also lets us all work together to find the right approach before you spend a bunch of time on a PR. So again, when in doubt, open an issue.
+
+## Developer Certificate of Origin
+
+OpenSearch is an open source product released under the Apache 2.0 license (see either [the Apache site](https://www.apache.org/licenses/LICENSE-2.0) or the [LICENSE](LICENSE) file). The Apache 2.0 license allows you to freely use, modify, distribute, and sell your own products that include Apache 2.0 licensed software.
+
+We respect intellectual property rights of others, and we want to make sure all incoming contributions are correctly attributed and licensed. A Developer Certificate of Origin (DCO) is a lightweight mechanism to do that.
+
+The DCO is a declaration attached to every contribution made by every developer. In the commit message of the contribution, the developer simply adds a `Signed-off-by` statement and thereby agrees to the DCO, which you can find below or at [DeveloperCertificate.org](http://developercertificate.org/).
+
+```
+Developer's Certificate of Origin 1.1
+By making a contribution to this project, I certify that:
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+(b) The contribution is based upon previous work that, to the
+    best of my knowledge, is covered under an appropriate open
+    source license and I have the right under that license to
+    submit that work with modifications, whether created in whole
+    or in part by me, under the same open source license (unless
+    I am permitted to submit under a different license), as
+    indicated in the file; or
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including
+    all personal information I submit with it, including my
+    sign-off) is maintained indefinitely and may be redistributed
+    consistent with this project or the open source license(s)
+    involved.
+```
+
+We require that every contribution to OpenSearch is signed with a Developer Certificate of Origin. Additionally, please use your real name. We do not accept anonymous contributors nor those utilizing pseudonyms.
+
+Each commit must include a DCO which looks like this
+
+```
+Signed-off-by: Jane Smith <jane.smith@email.com>
+```
+
+You may type this line on your own when writing your commit messages. However, if your user.name and user.email are set in your git configs, you can use `-s` or `--signoff` to add the `Signed-off-by` line to the end of the commit message.
+
+## Review Process
+
+We deeply appreciate everyone who takes the time to make a contribution. We will review all contributions as quickly as possible. As a reminder, [opening an issue](https://github.com/opensearch-project/opensearch-agent-server/issues/new/choose) discussing your change before you make it is the best way to smooth the PR process. This will prevent a rejection because someone else is already working on the problem, or because the solution is incompatible with the architectural direction.
+
+During the PR process, expect that there will be some back-and-forth. Please try to respond to comments in a timely fashion, and if you don't wish to continue with the PR, let us know. If a PR takes too many iterations for its complexity or size, we may reject it. Additionally, if you stop responding we may close the PR as abandoned. In either case, if you feel this was done in error, please add a comment on the PR.
+
+If we accept the PR, a [maintainer](MAINTAINERS.md) will merge your change and usually take care of backporting it to appropriate branches ourselves.
+
+If we reject the PR, we will close the pull request with a comment explaining why. This decision isn't always final: if you feel we have misunderstood your intended change or otherwise think that we should reconsider then please continue the conversation with a comment on the PR and we'll do our best to address any further points you raise.

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -1,0 +1,192 @@
+![OpenSearch logo](https://github.com/opensearch-project/opensearch-py/raw/main/OpenSearch.svg)
+
+# OpenSearch Agent Server Developer Guide
+
+## Table of Contents
+- [Overview](#overview)
+- [Development Setup](#development-setup)
+- [Running the Server](#running-the-server)
+- [Managing Dependencies](#managing-dependencies)
+- [Adding a New Agent](#adding-a-new-agent)
+- [Code Style](#code-style)
+- [Testing](#testing)
+
+## Overview
+
+This guide is for developers who want to contribute to the OpenSearch Agent Server project. It covers local development setup, running the server, and how to add new agents.
+
+The server is a multi-agent orchestrator that routes requests from OpenSearch Dashboards to specialized sub-agents based on page context. It exposes an [AG-UI](https://github.com/ag-ui-protocol/ag-ui) compatible HTTP API and uses [Strands Agents](https://github.com/strands-agents/sdk-python) as the agent runtime.
+
+## Development Setup
+
+### 1. Clone the Repository
+
+```bash
+git clone git@github.com:opensearch-project/opensearch-agent-server.git
+cd opensearch-agent-server
+```
+
+### 2. Install Dependencies
+
+This project uses [uv](https://docs.astral.sh/uv/) for package management.
+
+```bash
+# Create venv and install all dependencies (including dev extras)
+uv sync --extra dev
+
+# Activate the venv
+source .venv/bin/activate
+```
+
+### 3. Configure Environment
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` to set your OpenSearch URL, credentials, and LLM provider. At minimum you need:
+
+- `OPENSEARCH_URL` — your OpenSearch cluster endpoint
+- One LLM provider configured (AWS Bedrock or Ollama — see `.env.example` for options)
+- `MCP_SERVER_URL` — URL of a running [opensearch-mcp-server-py](https://github.com/opensearch-project/opensearch-mcp-server-py) instance
+
+### After Changing Dependencies
+
+```bash
+# After editing pyproject.toml, update lock file and sync
+uv lock
+uv sync --extra dev
+```
+
+## Running the Server
+
+```bash
+# With the venv activated
+source .venv/bin/activate
+opensearch-agent-server
+
+# Or without activating
+uv run opensearch-agent-server
+```
+
+The server starts on `http://localhost:8001` by default. OpenSearch Dashboards connects to it via the AG-UI protocol.
+
+## Managing Dependencies
+
+```bash
+# Add a runtime dependency
+uv add <package-name>
+
+# Add a development dependency
+uv add --dev <package-name>
+
+# Update all dependencies to latest allowed versions
+uv lock --upgrade
+uv sync --extra dev
+```
+
+## Adding a New Agent
+
+Follow the pattern established by `src/agents/art/`. Registration happens in `src/server/ag_ui_app.py`.
+
+### 1. Create your agent directory
+
+Add a subdirectory under `src/agents/` with at minimum an `__init__.py` and a module containing your factory function:
+
+```
+src/agents/my_agent/
+    __init__.py
+    my_agent.py
+    specialized_agents.py  # optional: constituent sub-agents
+```
+
+In `my_agent.py`, implement a factory function that returns a configured [Strands](https://github.com/strands-agents/sdk-python) `Agent`:
+
+```python
+from strands import Agent
+
+def create_my_agent(opensearch_url: str) -> Agent:
+    return Agent(
+        system_prompt="You are an OpenSearch assistant ...",
+        tools=[...],
+    )
+```
+
+### 2. Register the agent in `ag_ui_app.py`
+
+In `src/server/ag_ui_app.py`, import your factory and add two registrations alongside the existing `art` and `default` entries:
+
+```python
+from agents.my_agent.my_agent import create_my_agent
+from orchestrator.registry import AgentRegistration
+
+# 1. Register with the AgentRegistry (used for routing)
+registry.register(AgentRegistration(
+    name="my-agent",
+    description="What this agent does.",
+    page_contexts=["my-page-context"],  # Dashboards page(s) that route here
+    is_default=False,
+))
+
+# 2. Register the factory with the orchestrator (used to instantiate per request)
+orchestrator.register_agent_factory(
+    name="my-agent",
+    factory=lambda: create_my_agent(opensearch_url),
+    description="What this agent does.",
+    config=context_config,
+)
+```
+
+The `page_contexts` list controls which OpenSearch Dashboards page context strings route to your agent. Any unmatched context falls through to the default agent.
+
+### 3. Write tests
+
+Add unit tests under `tests/` covering your factory function and any agent-specific logic. See existing tests for patterns.
+
+### 4. Update documentation
+
+If your agent adds new environment variables or configuration options, update `README.md` and `.env.example`.
+
+## Code Style
+
+This project is configured to use [ruff](https://docs.astral.sh/ruff/) for linting and formatting (see `[tool.ruff]` in `pyproject.toml`). Running it before opening a PR is recommended:
+
+```bash
+# Format code
+uv run ruff format .
+
+# Check for lint issues
+uv run ruff check .
+```
+
+All new source files must include the Apache 2.0 license header:
+
+```python
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+```
+
+## Testing
+
+### Running Tests
+
+```bash
+# Run all tests
+uv run pytest
+
+# Run only unit tests
+uv run pytest -m unit
+
+# Run with coverage report
+uv run pytest --cov=server --cov=agents --cov=orchestrator
+```
+
+### Integration Tests
+
+Integration tests require a running OpenSearch instance. Set the connection variables in your `.env` (or export them), then run:
+
+```bash
+uv run pytest -m integration
+```
+
+All new features and bug fixes must include tests. PRs that reduce test coverage will be asked to add tests before merging.

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -32,7 +32,7 @@ This project uses [uv](https://docs.astral.sh/uv/) for package management.
 
 ```bash
 # Create venv and install all dependencies (including dev extras)
-uv sync --extra dev
+uv sync --all-extras
 
 # Activate the venv
 source .venv/bin/activate
@@ -55,7 +55,7 @@ Edit `.env` to set your OpenSearch URL, credentials, and LLM provider. At minimu
 ```bash
 # After editing pyproject.toml, update lock file and sync
 uv lock
-uv sync --extra dev
+uv sync --all-extras
 ```
 
 ## Running the Server
@@ -82,7 +82,7 @@ uv add --dev <package-name>
 
 # Update all dependencies to latest allowed versions
 uv lock --upgrade
-uv sync --extra dev
+uv sync --all-extras
 ```
 
 ## Adding a New Agent
@@ -182,8 +182,6 @@ uv run pytest --cov=server --cov=agents --cov=orchestrator
 ```
 
 ### Integration Tests
-
-Integration tests require a running OpenSearch instance. Set the connection variables in your `.env` (or export them), then run:
 
 ```bash
 uv run pytest -m integration

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,9 +1,2 @@
 OpenSearch (https://opensearch.org/)
 Copyright OpenSearch Contributors
-
-This product includes software developed by
-OpenSearch (https://opensearch.org/).
-
-This software contains unmodified binary redistributions for
-third-party software components, subject to the license terms of
-those components. See the LICENSE file for the full license text.

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,2 +1,9 @@
 OpenSearch (https://opensearch.org/)
 Copyright OpenSearch Contributors
+
+This product includes software developed by
+OpenSearch (https://opensearch.org/).
+
+This software contains unmodified binary redistributions for
+third-party software components, subject to the license terms of
+those components. See the LICENSE file for the full license text.

--- a/README.md
+++ b/README.md
@@ -396,13 +396,10 @@ uvicorn server.ag_ui_app:app --host 0.0.0.0 --port 8002
 
 ## Contributing
 
-Contributions are welcome! Please:
+Contributions are welcome! Check out our:
 
-1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
+- [Contributing Guidelines](CONTRIBUTING.md) — how to report bugs, request features, and submit pull requests
+- [Developer Guide](DEVELOPER_GUIDE.md) — how to set up your environment and add a new agent
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Security
+
+If you discover a potential security issue in this project, please do **not** create a public GitHub issue. Instead, notify the OpenSearch Security Team by emailing [security@opensearch.org](mailto:security@opensearch.org).
+
+Include as much detail as possible to help reproduce and resolve the issue quickly.


### PR DESCRIPTION
### Description
This PR adds missing files for OSS readiness (`CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, `SECURITY.md`) and adds a `DEVELOPER_GUIDE.md` file including how to add a new agent to the agent server.

### Issues Resolved
closes #6 & #25 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
