### PR TITLE
Add non-streaming `/invoke` endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Added
 - Support using Ollama as model provider
 - PPL reference skill and skills auto-discovery for the default agent
+- Support non-streaming `/invoke` endpoint
 
 ### Fixed
 - Default agent now respects `BEDROCK_INFERENCE_PROFILE_ARN` env var instead of silently falling back to a hardcoded Sonnet 4 model (fixes #94)

--- a/src/server/ag_ui_app.py
+++ b/src/server/ag_ui_app.py
@@ -67,6 +67,7 @@ from server.rate_limiting import (  # noqa: E402
 )
 from server.request_id_middleware import RequestIdMiddleware  # noqa: E402
 from server.run_routes import (  # noqa: E402
+    _extract_auth_headers,
     cancel_run_route,
     create_run_route,
     get_run_events_route,
@@ -634,6 +635,75 @@ async def cancel_run(run_id: str, request: Request) -> CancelRunResponse:
         persistence=persistence, run_id=run_id, request=request
     )
 
+@app.post("/invoke", tags=["invoke"])
+@rate_limit
+async def invoke(
+    request: Request,
+    orch: AgentOrchestrator = Depends(get_orchestrator),
+) -> JSONResponse:
+    """Non-streaming endpoint.
+
+    Runs the agent to completion and returns the final response as JSON.
+    Accepts a string query or message list (Strands Agent interface).
+    """
+    body = await request.json()
+    query = body.get("query")
+    messages = body.get("messages")
+    agent_name = body.get("agent")
+    timeout = body.get("timeout", 600)
+
+    if not query and not messages:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error": "Request must include 'query' or 'messages'.",
+                "error_type": "ValidationError",
+                "status": "error",
+            },
+        )
+
+    if messages:
+        prompt: str | list[dict] = [
+            {"role": m["role"], "content": [{"text": m["content"]}]}
+            for m in messages
+        ]
+    else:
+        prompt = query
+
+    forwarded_headers = _extract_auth_headers(request)
+
+    try:
+        response_text = await orch.invoke(
+            prompt=prompt,
+            agent_name=agent_name,
+            headers=forwarded_headers,
+            timeout=timeout,
+        )
+        return JSONResponse(content={"response": response_text, "status": "success"})
+    except TimeoutError as e:
+        return JSONResponse(
+            status_code=408,
+            content={
+                "error": str(e),
+                "error_type": "TimeoutError",
+                "status": "error",
+            },
+        )
+    except Exception as e:
+        log_info_event(
+            logger,
+            f"Invoke error: {e}",
+            "invoke.error",
+            error=str(e),
+        )
+        return JSONResponse(
+            status_code=500,
+            content={
+                "error": str(e),
+                "error_type": type(e).__name__,
+                "status": "error",
+            },
+        )
 
 if __name__ == "__main__":
     import uvicorn

--- a/src/server/agent_orchestrator.py
+++ b/src/server/agent_orchestrator.py
@@ -10,6 +10,7 @@ instances stored on each agent's httpx client — the orchestrator calls
 
 from __future__ import annotations
 
+import asyncio
 import json
 from collections.abc import AsyncIterator, Callable
 from typing import Any
@@ -208,6 +209,76 @@ class AgentOrchestrator:
                 yield event
         finally:
             mcp_client = getattr(strands_agent, "_mcp_client", None)
+            if mcp_client is not None:
+                try:
+                    mcp_client.stop()
+                except Exception:
+                    pass
+
+    async def invoke(
+        self,
+        prompt: str | list[dict],
+        agent_name: str | None = None,
+        headers: dict[str, str] | None = None,
+        timeout: float = 600,
+    ) -> str:
+        """Invoke an agent synchronously and return the final response.
+
+        Unlike :meth:`run` which streams AG-UI events, this calls the Strands
+        Agent directly and returns the complete text response.
+
+        Args:
+            prompt: String query or message list for the Strands Agent.
+            agent_name: Explicit agent name. If ``None``, uses the default agent.
+            headers: Optional HTTP headers forwarded from the request.
+            timeout: Maximum seconds to wait for the agent to complete.
+
+        Returns:
+            The agent's final response as a string.
+
+        Raises:
+            RuntimeError: If no agent factory is registered with the given name.
+            TimeoutError: If the agent does not complete within the timeout.
+        """
+
+        if agent_name is None:
+            agent_name = self._router.route(None).name
+
+        factory_info = self._agent_factories.get(agent_name)
+        if factory_info is None:
+            raise RuntimeError(
+                f"No agent factory registered with name '{agent_name}'. "
+                f"Available: {list(self._agent_factories)}"
+            )
+
+        agent = factory_info["factory"]()
+
+        token = _extract_bearer_token(headers)
+        obo_auth = getattr(agent, "_obo_auth", None)
+        if obo_auth is not None:
+            obo_auth.set_token(token)
+
+        log_info_event(
+            logger,
+            f"Invoking agent '{agent_name}' (non-streaming, timeout={timeout}s)",
+            "orchestrator.invoke",
+            agent_name=agent_name,
+            timeout=timeout,
+        )
+
+        try:
+            result = await asyncio.wait_for(
+                asyncio.to_thread(agent, prompt),
+                timeout=timeout,
+            )
+            return str(result) if result else ""
+        except asyncio.TimeoutError:
+            agent.cancel()
+            raise TimeoutError(
+                f"Agent '{agent_name}' did not complete within {timeout}s."
+            )
+        finally:
+            mcp_client = getattr(agent, "_mcp_client", None)
             if mcp_client is not None:
                 try:
                     mcp_client.stop()

--- a/tests/unit/test_invoke_endpoint.py
+++ b/tests/unit/test_invoke_endpoint.py
@@ -1,0 +1,190 @@
+"""Unit tests for the /invoke non-streaming endpoint."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from server.ag_ui_app import app, get_orchestrator
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def mock_orchestrator():
+    """Create a mock AgentOrchestrator with a working invoke method."""
+    orch = MagicMock()
+    orch.invoke = AsyncMock(return_value="This is the agent response.")
+    return orch
+
+
+@pytest.fixture
+def client(mock_orchestrator):
+    """FastAPI TestClient with orchestrator dependency overridden."""
+    app.dependency_overrides[get_orchestrator] = lambda: mock_orchestrator
+    with patch("server.ag_ui_app.rate_limit", lambda f: f):
+        yield TestClient(app, raise_server_exceptions=False)
+    app.dependency_overrides.clear()
+
+
+class TestInvokeEndpoint:
+    """Tests for POST /invoke."""
+
+    def test_query_string_returns_success(self, client, mock_orchestrator):
+        """Simple string query returns the agent response."""
+        response = client.post("/invoke", json={"query": "What indexes exist?"})
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "success"
+        assert body["response"] == "This is the agent response."
+        mock_orchestrator.invoke.assert_called_once_with(
+            prompt="What indexes exist?",
+            agent_name=None,
+            headers=None,
+            timeout=600,
+        )
+
+    def test_messages_list_returns_success(self, client, mock_orchestrator):
+        """Message list input is converted to Strands format."""
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there"},
+        ]
+        response = client.post("/invoke", json={"messages": messages})
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "success"
+
+        expected_prompt = [
+            {"role": "user", "content": [{"text": "Hello"}]},
+            {"role": "assistant", "content": [{"text": "Hi there"}]},
+        ]
+        mock_orchestrator.invoke.assert_called_once_with(
+            prompt=expected_prompt,
+            agent_name=None,
+            headers=None,
+            timeout=600,
+        )
+
+    def test_explicit_agent_name(self, client, mock_orchestrator):
+        """Agent name from request body is passed to orchestrator."""
+        response = client.post(
+            "/invoke", json={"query": "hi", "agent": "decomposer"}
+        )
+
+        assert response.status_code == 200
+        mock_orchestrator.invoke.assert_called_once_with(
+            prompt="hi",
+            agent_name="decomposer",
+            headers=None,
+            timeout=600,
+        )
+
+    def test_missing_query_and_messages_returns_400(self, client, mock_orchestrator):
+        """Request without query or messages returns 400."""
+        response = client.post("/invoke", json={"agent": "default"})
+
+        assert response.status_code == 400
+        body = response.json()
+        assert body["status"] == "error"
+        assert body["error_type"] == "ValidationError"
+        assert "query" in body["error"]
+        mock_orchestrator.invoke.assert_not_called()
+
+    def test_unknown_agent_returns_500(self, client, mock_orchestrator):
+        """RuntimeError from orchestrator (unknown agent) returns 500."""
+        mock_orchestrator.invoke = AsyncMock(
+            side_effect=RuntimeError(
+                "No agent factory registered with name 'bad'. Available: ['default']"
+            )
+        )
+
+        response = client.post(
+            "/invoke", json={"query": "hi", "agent": "bad"}
+        )
+
+        assert response.status_code == 500
+        body = response.json()
+        assert body["status"] == "error"
+        assert body["error_type"] == "RuntimeError"
+        assert "bad" in body["error"]
+
+    def test_error_response_has_no_traceback(self, client, mock_orchestrator):
+        """Error responses must not leak tracebacks."""
+        mock_orchestrator.invoke = AsyncMock(
+            side_effect=ValueError("something broke")
+        )
+
+        response = client.post("/invoke", json={"query": "hi"})
+
+        body = response.json()
+        assert "traceback" not in body
+
+    def test_auth_headers_forwarded(self, client, mock_orchestrator):
+        """Authorization header is forwarded to the orchestrator."""
+        response = client.post(
+            "/invoke",
+            json={"query": "hi"},
+            headers={"Authorization": "Bearer test-token-123"},
+        )
+
+        assert response.status_code == 200
+        mock_orchestrator.invoke.assert_called_once_with(
+            prompt="hi",
+            agent_name=None,
+            headers={"authorization": "Bearer test-token-123"},
+            timeout=600,
+        )
+
+    def test_empty_agent_response(self, client, mock_orchestrator):
+        """Empty agent response still returns success."""
+        mock_orchestrator.invoke = AsyncMock(return_value="")
+
+        response = client.post("/invoke", json={"query": "hi"})
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "success"
+        assert body["response"] == ""
+
+    def test_timeout_returns_408(self, client, mock_orchestrator):
+        """Request that exceeds timeout returns 408."""
+        mock_orchestrator.invoke = AsyncMock(
+            side_effect=TimeoutError("Agent 'default' did not complete within 1s.")
+        )
+
+        response = client.post("/invoke", json={"query": "hi", "timeout": 1})
+
+        assert response.status_code == 408
+        body = response.json()
+        assert body["status"] == "error"
+        assert body["error_type"] == "TimeoutError"
+
+    def test_custom_timeout_passed_to_orchestrator(self, client, mock_orchestrator):
+        """Custom timeout value from request body is passed to orchestrator."""
+        response = client.post(
+            "/invoke", json={"query": "hi", "timeout": 300}
+        )
+
+        assert response.status_code == 200
+        mock_orchestrator.invoke.assert_called_once_with(
+            prompt="hi",
+            agent_name=None,
+            headers=None,
+            timeout=300,
+        )
+
+    def test_default_timeout_is_600(self, client, mock_orchestrator):
+        """Default timeout is 600 seconds when not specified."""
+        response = client.post("/invoke", json={"query": "hi"})
+
+        assert response.status_code == 200
+        mock_orchestrator.invoke.assert_called_once_with(
+            prompt="hi",
+            agent_name=None,
+            headers=None,
+            timeout=600,
+        )

--- a/tests/unit/test_orchestrator_concurrency.py
+++ b/tests/unit/test_orchestrator_concurrency.py
@@ -275,3 +275,125 @@ class TestPerRequestAgentCreation:
                     pass
 
         assert len(orchestrator._agents_created) == 5
+
+
+class TestInvokeCredentialIsolation:
+    """Tests that concurrent /invoke requests get isolated credentials."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_invoke_requests_get_separate_agents(
+        self, orchestrator
+    ):
+        """Each concurrent invoke request must create its own agent instance."""
+        async def run_invoke(token):
+            return await orchestrator.invoke(
+                prompt="hello",
+                agent_name="default",
+                headers={"authorization": f"Bearer {token}"},
+            )
+
+        await asyncio.gather(
+            run_invoke("token_A"),
+            run_invoke("token_B"),
+        )
+
+        assert len(orchestrator._agents_created) == 2
+
+    @pytest.mark.asyncio
+    async def test_invoke_each_request_gets_its_own_token(self, orchestrator):
+        """Each invoke agent instance gets the correct token."""
+        await orchestrator.invoke(
+            prompt="hello",
+            agent_name="default",
+            headers={"authorization": "Bearer token_alice"},
+        )
+        await orchestrator.invoke(
+            prompt="hello",
+            agent_name="default",
+            headers={"authorization": "Bearer token_bob"},
+        )
+
+        alice_agent = orchestrator._agents_created[0]
+        bob_agent = orchestrator._agents_created[1]
+
+        alice_agent._obo_auth.set_token.assert_called_once_with("token_alice")
+        bob_agent._obo_auth.set_token.assert_called_once_with("token_bob")
+
+    @pytest.mark.asyncio
+    async def test_invoke_no_shared_obo_auth(self, orchestrator):
+        """Each invoke request must have a different OboAuth instance."""
+        await orchestrator.invoke(
+            prompt="hello", agent_name="default", headers=None
+        )
+        await orchestrator.invoke(
+            prompt="hello", agent_name="default", headers=None
+        )
+
+        agent_1 = orchestrator._agents_created[0]
+        agent_2 = orchestrator._agents_created[1]
+        assert agent_1._obo_auth is not agent_2._obo_auth
+
+
+class TestInvokeMcpClientCleanup:
+    """Tests that /invoke properly cleans up MCP client resources."""
+
+    @pytest.mark.asyncio
+    async def test_invoke_mcp_client_stopped_after_success(self, orchestrator):
+        """MCP client must be stopped after a successful invoke."""
+        await orchestrator.invoke(
+            prompt="hello", agent_name="default", headers=None
+        )
+
+        agent = orchestrator._agents_created[0]
+        agent._mcp_client.stop.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_invoke_mcp_client_stopped_on_error(self, orchestrator):
+        """MCP client must be stopped even if invoke raises."""
+        # Make the agent call raise
+        def failing_agent(prompt):
+            raise RuntimeError("agent exploded")
+
+        original_factory = orchestrator._agent_factories["default"]["factory"]
+
+        def factory_that_fails():
+            agent = original_factory()
+            agent.side_effect = RuntimeError("agent exploded")
+            return agent
+
+        orchestrator._agent_factories["default"]["factory"] = factory_that_fails
+
+        with pytest.raises(RuntimeError):
+            await orchestrator.invoke(
+                prompt="hello", agent_name="default", headers=None
+            )
+
+        agent = orchestrator._agents_created[0]
+        agent._mcp_client.stop.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_invoke_no_mcp_client_does_not_error(self, orchestrator):
+        """Agent without _mcp_client should not error on cleanup."""
+        original_factory = orchestrator._agent_factories["default"]["factory"]
+
+        def factory_no_mcp():
+            agent = original_factory()
+            del agent._mcp_client
+            return agent
+
+        orchestrator._agent_factories["default"]["factory"] = factory_no_mcp
+
+        # Should not raise
+        await orchestrator.invoke(
+            prompt="hello", agent_name="default", headers=None
+        )
+
+    @pytest.mark.asyncio
+    async def test_invoke_factory_called_every_request(self, orchestrator):
+        """Factory must be called on every invoke, not cached."""
+        for _ in range(5):
+            await orchestrator.invoke(
+                prompt="hello", agent_name="default", headers=None
+            )
+
+        assert len(orchestrator._agents_created) == 5


### PR DESCRIPTION
### Description

#### Summary
  - Adds `POST /invoke` — a synchronous JSON request/response endpoint for programmatic consumers that don't need streaming
  - Calls the Strands Agent directly and returns the complete response in a single JSON payload
  - Shares the same agent factories, MCP tools, and credential forwarding as the streaming `/runs` endpoint

#### Details

The agent server currently only supports streaming via AG-UI protocol (`/runs`). However, programmatic consumers (e.g., agentic search) don't need SSE — they just want the final answer as JSON. This endpoint provides that without the overhead of event parsing, synthetic session IDs, or SSE client setup.

  Key design choices:
  - Adds `AgentOrchestrator.invoke()` method mirroring `run()` but returning text instead of AG-UI events
  - Creates a fresh agent per request for credential isolation 
  - Runs agent in thread pool (`asyncio.to_thread`) to avoid blocking the event loop
  - Input validation returns 400 if neither `query` nor `messages` is provided

#### Sample Requests & Responses
-   Simple query (uses default agent)
```
  curl -X POST http://localhost:8001/invoke \
    -H "Content-Type: application/json" \
    -d '{"query": "List indices in my cluster"}'
  {
    "response": "Here are all the indices in your OpenSearch cluster:\n\n## System/Plugin Indices:\n- **`.plugins-ml-model-group`** (Green, 2 docs, 5.8kb)\n- **`.plugins-ml-memory-message`** (Green, 120 docs, 
  118.5kb)\n...\n\n**Summary:**\n- Total: 19 indices\n- Health: 18 green, 1 yellow\n",
    "status": "success"
  }
```
- Explicit agent name
```
  curl -X POST http://localhost:8001/invoke \
    -H "Content-Type: application/json" \
    -d '{"query": "Hello", "agent": "default"}'
  {
    "response": "Hello! I'm here to help you with your OpenSearch cluster. I can assist you with various tasks such as:\n\n- **Cluster Health**: Check the overall health and status of your cluster\n- **Index 
  Management**: List indices, view mappings, create or delete indices\n...\n\nJust let me know what you need help with!\n",
    "status": "success"
  }
```
- Message list input
```
  curl -X POST http://localhost:8001/invoke \
    -H "Content-Type: application/json" \
    -d '{"messages": [{"role": "user", "content": "What is OpenSearch?"}]}'
  {
    "response": "OpenSearch is an open-source, distributed search and analytics engine built on Apache Lucene...\n\nWould you like me to help you explore your OpenSearch cluster or learn about any specific 
  features?\n", 
    "status": "success"
  } 
```
- Validation error (missing query and messages)
```
  curl -X POST http://localhost:8001/invoke \
    -H "Content-Type: application/json" \
    -d '{"agent": "default"}'
  {
    "error": "Request must include 'query' or 'messages'.",
    "error_type": "ValidationError",
    "status": "error"
  }
```
- Unknown agent
```
  curl -X POST http://localhost:8001/invoke \
    -H "Content-Type: application/json" \
    -d '{"query": "hi", "agent": "nonexistent"}'
  {
    "error": "No agent factory registered with name 'nonexistent'. Available: ['default', 'art']",
    "error_type": "RuntimeError",
    "status": "error"
  }
```

#### Test plan

  - [x] Unit tests added (`tests/unit/test_invoke_endpoint.py` — 8 tests covering happy paths, validation, error handling, auth forwarding)
  - [x] Manual testing with curl against local server (all cases above verified)

### Issues Resolved
Resolves https://github.com/opensearch-project/opensearch-agent-server/issues/133

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
