### PR TITLE
test: cover PageContextRouter routing tiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Added
+- Unit coverage for exact, fallback, missing-default, and case-sensitive page-context routing (#9)
 - Support using Ollama as model provider
 - PPL reference skill and skills auto-discovery for the default agent
 

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -1,0 +1,72 @@
+"""Unit tests for page-context routing."""
+
+from __future__ import annotations
+
+import pytest
+
+from orchestrator.registry import AgentRegistration, AgentRegistry
+from orchestrator.router import PageContextRouter
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def registered_agents() -> tuple[AgentRegistry, AgentRegistration, AgentRegistration]:
+    registry = AgentRegistry()
+    fallback = AgentRegistration(
+        name="default",
+        description="Fallback agent",
+        is_default=True,
+    )
+    discover = AgentRegistration(
+        name="discover",
+        description="Discover page agent",
+        page_contexts=["discover"],
+    )
+    registry.register(fallback)
+    registry.register(discover)
+    return registry, fallback, discover
+
+
+def test_exact_page_context_routes_to_registered_agent(registered_agents):
+    registry, _, discover = registered_agents
+
+    assert PageContextRouter(registry).route("discover") is discover
+
+
+def test_unknown_page_context_routes_to_fallback(registered_agents):
+    registry, fallback, _ = registered_agents
+
+    assert PageContextRouter(registry).route("unknown") is fallback
+
+
+def test_none_page_context_routes_to_fallback(registered_agents):
+    registry, fallback, _ = registered_agents
+
+    assert PageContextRouter(registry).route(None) is fallback
+
+
+def test_empty_page_context_routes_to_fallback(registered_agents):
+    registry, fallback, _ = registered_agents
+
+    assert PageContextRouter(registry).route("") is fallback
+
+
+def test_missing_fallback_raises_runtime_error():
+    registry = AgentRegistry()
+    registry.register(
+        AgentRegistration(
+            name="discover",
+            description="Discover page agent",
+            page_contexts=["discover"],
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="No default agent registered"):
+        PageContextRouter(registry).route("unknown")
+
+
+def test_page_context_matching_is_case_sensitive(registered_agents):
+    registry, fallback, _ = registered_agents
+
+    assert PageContextRouter(registry).route("Discover") is fallback


### PR DESCRIPTION
## Summary

- cover exact page-context matches returning the specialized agent
- cover unknown, `None`, and empty contexts falling back to the default agent
- verify a missing default raises the documented `RuntimeError`
- pin the current case-sensitive matching behavior
- record the test coverage in the unreleased changelog

Closes #9.

This complements #129: that PR tests `AgentRegistry` registration and lookup behavior, while this PR tests the separate `PageContextRouter.route()` tier and fallback contract requested by #9.

## Validation

- `PYTHONPATH=src python -m pytest tests/unit/test_router.py -v --tb=short` — 6 passed
- `ruff check tests/unit/test_router.py`
- `ruff format --check tests/unit/test_router.py`
- `git diff --check`

The focused tests ran in an isolated Python 3.12 environment. Repository CI will run the full unit suite across Linux, macOS, and Windows.