### PR TITLE
Port NLQ→DSL generation to the OpenSearch Agent Server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Support using Ollama as model provider
 - PPL reference skill and skills auto-discovery for the default agent
 - Support non-streaming `/invoke` endpoint
+- `agentic_search` agent (natural-language query -> OpenSearch DSL) reachable via `POST /invoke`, with a per-request generation strategy (`context.strategy`, default `direct_dsl`) and example ml-commons connector/FLOW-agent wiring
+- `/invoke` `context` (structured input forwarded to the agent) and `response_format` (opt-in ml-commons `inference_results` envelope) request fields
 
 ### Fixed
 - Default agent now respects `BEDROCK_INFERENCE_PROFILE_ARN` env var instead of silently falling back to a hardcoded Sonnet 4 model (fixes #94)

--- a/examples/agentic-search/README.md
+++ b/examples/agentic-search/README.md
@@ -1,0 +1,96 @@
+# Wiring ml-commons to the agent server `/invoke` endpoint
+
+Example registrations that connect an OpenSearch cluster's agentic-search path to
+the agent server's `/invoke` endpoint, targeting the `agentic_search` agent. This
+is **configuration, not code** — JSON you POST to a running cluster's REST API. No
+ml-commons Java is involved; the only code is the agent server's `agentic_search`
+agent (`src/agents/agentic_search/`), reached through `/invoke`.
+
+## How the DSL reaches neural-search
+
+`extractFlowAgentResult` (neural-search) reads the generated DSL only from
+`ModelTensor.result` (a string). A stock `ConnectorTool` would park an HTTP JSON
+response in `dataAsMap`, leaving `result` empty. The connector sends
+`response_format: inference_results`, so `/invoke` returns the ml-commons envelope;
+the built-in `post_process_function: connector.post_process.mlcommons.passthrough`
+then copies `output[0].result` into `ModelTensor.result`.
+
+## Register against a cluster
+
+Requires a running OpenSearch cluster with ml-commons (e.g. `./gradlew run`) and a
+reachable agent server.
+
+### 1. Register the connector
+
+Describes the HTTP call to `/invoke`. `${parameters.question}` and
+`${parameters.index_name}` are filled from the FLOW agent's runtime parameters at
+call time; `agent` selects `agentic_search`; `response_format: inference_results`
+makes `/invoke` return the envelope the passthrough reads. Set
+`parameters.endpoint` to your agent server's host. The `Authorization` header must
+use `${credential.*}` — security-sensitive headers reject `${parameters.*}`.
+
+```bash
+curl -s -XPOST http://localhost:9200/_plugins/_ml/connectors/_create \
+  -H 'Content-Type: application/json' -d '{
+  "name": "Agentic Search Remote DSL Connector",
+  "description": "Calls the agent server /invoke endpoint (agentic_search agent).",
+  "version": "1",
+  "protocol": "http",
+  "parameters": { "endpoint": "127.0.0.1:8001" },
+  "credential": { "token": "replace-with-agent-server-token" },
+  "actions": [{
+    "action_type": "predict",
+    "method": "POST",
+    "url": "http://${parameters.endpoint}/invoke",
+    "headers": {
+      "Content-Type": "application/json",
+      "Authorization": "Bearer ${credential.token}"
+    },
+    "request_body": "{ \"query\": \"${parameters.question}\", \"agent\": \"agentic_search\", \"context\": { \"index_name\": \"${parameters.index_name}\" }, \"response_format\": \"inference_results\" }",
+    "post_process_function": "connector.post_process.mlcommons.passthrough"
+  }]
+}'
+#    -> {"connector_id":"abc123..."}
+```
+
+### 2. Register the FLOW agent
+
+A single-tool FLOW agent returns its tool's output directly. Paste the
+`connector_id` from step 1; `connector_action: predict` matches the connector's
+action above.
+
+```bash
+curl -s -XPOST http://localhost:9200/_plugins/_ml/agents/_register \
+  -H 'Content-Type: application/json' -d '{
+  "name": "Agentic Search Remote DSL Agent",
+  "type": "flow",
+  "description": "Single-tool FLOW agent that generates OpenSearch DSL via the agent server.",
+  "tools": [{
+    "type": "ConnectorTool",
+    "name": "remote_dsl_generator",
+    "description": "Generates OpenSearch DSL from a natural-language question.",
+    "parameters": { "connector_id": "PASTE_CONNECTOR_ID_FROM_STEP_1", "connector_action": "predict" }
+  }]
+}'
+#    -> {"agent_id":"xyz789..."}
+```
+
+### 3. Execute the agent
+
+```bash
+curl -s -XPOST http://localhost:9200/_plugins/_ml/agents/<agent_id>/_execute \
+  -H 'Content-Type: application/json' \
+  -d '{"parameters":{"question":"active items","index_name":"my-index"}}'
+```
+
+The `_execute` response carries the generated DSL in its `result` field,
+confirming the connector → passthrough → `ModelTensor.result` chain.
+
+## Notes
+
+- If the cluster's trusted-endpoints regex blocks the host, add it via
+  `plugins.ml_commons.trusted_connector_endpoints_regex` (do not widen this in
+  production).
+- If the agent server is on a private IP (e.g. `localhost` or an in-VPC host),
+  ml-commons rejects the connector with "host name has private ip address" unless
+  `plugins.ml_commons.connector.private_ip_enabled` is `true`.

--- a/src/agents/agentic_search/__init__.py
+++ b/src/agents/agentic_search/__init__.py
@@ -1,0 +1,10 @@
+"""Agentic-search agent: natural-language query -> OpenSearch DSL, via ``POST /invoke``."""
+
+from __future__ import annotations
+
+from agents.agentic_search.agent import (
+    AgenticSearchAgent,
+    create_agentic_search_agent,
+)
+
+__all__ = ["AgenticSearchAgent", "create_agentic_search_agent"]

--- a/src/agents/agentic_search/agent.py
+++ b/src/agents/agentic_search/agent.py
@@ -1,0 +1,108 @@
+"""The ``agentic_search`` agent: NLQ -> OpenSearch DSL, reached via ``POST /invoke``.
+
+Given a natural-language ``query`` and a target ``index_name`` (in the structured
+``context``), the agent fetches the index mapping with the caller's forwarded
+credentials, dispatches to the generation strategy named by ``context.strategy``
+(default ``direct_dsl``), and returns the ``_search`` body as a JSON string. Any
+failure degrades to a broad ``match_all`` so the upstream search returns a safe
+result set instead of erroring.
+
+Registered via :func:`create_agentic_search_agent`, following the same factory
+convention as the other agents in ``src/agents``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from opensearchpy import OpenSearch
+
+from agents.agentic_search.prompts import FALLBACK_DSL
+from agents.agentic_search.strategies import DEFAULT_STRATEGY, STRATEGIES
+from agents.agentic_search.strategies.base import GenerationRequest, GenerationStrategy
+from utils.model_factory import create_model
+
+logger = logging.getLogger(__name__)
+
+
+class AgenticSearchAgent:
+    """Adapts NLQ->DSL generation to the orchestrator's ``/invoke`` convention.
+
+    The orchestrator calls a context-aware agent as
+    ``agent(prompt, context=..., auth_token=...)``: ``prompt`` is the NLQ (the
+    ``query`` field), ``context`` carries ``index_name`` and an optional
+    ``strategy``, and ``auth_token`` is the caller's forwarded bearer token used
+    to reach the cluster. Returns the ``_search`` body as a JSON string.
+    """
+
+    # Signals the orchestrator to pass context + auth_token, not just the prompt.
+    accepts_invoke_context = True
+
+    def __init__(self, opensearch_url: str) -> None:
+        self._opensearch_url = opensearch_url
+        # Built once and reused across calls; the provider/credentials are fixed
+        # for the process, while each request gets a fresh stateless Agent.
+        self._model = create_model()
+
+    def __call__(
+        self,
+        prompt: str | list[dict],
+        context: dict[str, Any] | None = None,
+        auth_token: str | None = None,
+    ) -> str:
+        try:
+            return json.dumps(self._generate(prompt, context, auth_token))
+        except Exception:  # noqa: BLE001 - any failure degrades to the fallback
+            logger.exception("Agentic-search generation failed; returning fallback")
+            return FALLBACK_DSL
+
+    def _generate(
+        self,
+        prompt: str | list[dict],
+        context: dict[str, Any] | None,
+        auth_token: str | None,
+    ) -> dict[str, Any]:
+        context = context if isinstance(context, dict) else {}
+        if not isinstance(prompt, str) or not prompt.strip():
+            raise ValueError("query must be a non-empty string")
+        index_name = context.get("index_name")
+        if not index_name:
+            raise ValueError("context.index_name is required")
+
+        strategy_name = context.get("strategy", DEFAULT_STRATEGY)
+        strategy: GenerationStrategy | None = STRATEGIES.get(strategy_name)
+        if strategy is None:
+            raise ValueError(f"unknown strategy '{strategy_name}'")
+
+        client = self._client(auth_token)
+        mapping = json.dumps(client.indices.get_mapping(index=index_name))
+        dsl = strategy.generate(
+            GenerationRequest(
+                question=prompt,
+                index_name=index_name,
+                mapping=mapping,
+                context=context,
+                model=self._model,
+                client=client,
+            )
+        )
+
+        # Guard the contract: a strategy must return a JSON object (a _search
+        # body). Anything else degrades to the fallback rather than reaching the
+        # cluster as an invalid query.
+        if not isinstance(dsl, dict):
+            raise ValueError("strategy did not return a _search body object")
+        return dsl
+
+    def _client(self, auth_token: str | None) -> OpenSearch:
+        # Forward the caller's bearer token per request when present; otherwise
+        # the client falls back to its environment configuration.
+        headers = {"Authorization": f"Bearer {auth_token}"} if auth_token else None
+        return OpenSearch(hosts=[self._opensearch_url], headers=headers, timeout=30)
+
+
+def create_agentic_search_agent(opensearch_url: str) -> AgenticSearchAgent:
+    """Create the ``agentic_search`` agent (factory used at startup registration)."""
+    return AgenticSearchAgent(opensearch_url)

--- a/src/agents/agentic_search/prompts.py
+++ b/src/agents/agentic_search/prompts.py
@@ -1,0 +1,303 @@
+"""Prompt, structured-output schema, and cached system blocks for direct-DSL generation.
+
+The system prompt is a large, static rules-and-examples prefix. It is sent as
+Bedrock content blocks with a trailing cache point so it is served from cache on
+warm calls (Bedrock only; harmlessly ignored elsewhere); the per-request mapping
+and question go in the user message, after the cached prefix.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+from strands.types.content import SystemContentBlock
+
+# Broad match_all body used as the safe fallback when generation fails or no
+# mapping field is relevant to the question.
+FALLBACK_DSL = '{"size":10,"query":{"match_all":{}}}'
+
+
+class EmitSearch(BaseModel):
+    """Structured output the model returns: the DSL plus a one-line rationale.
+
+    ``dsl`` is an open object (no rigid sub-schema) so the model can emit any
+    valid OpenSearch query body.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    reason: str = Field(
+        description="One short line mapping each clause of the DSL to the user's words."
+    )
+    dsl: dict[str, Any] = Field(
+        description="The OpenSearch _search request body as a JSON object."
+    )
+
+
+QUERY_TYPE_RULES = (
+    "Use only fields present in the provided mapping; never invent names.\n"
+    "Choose query types based on user intent and field types:\n"
+    "- match: single-token full-text on analyzed text fields.\n"
+    "- match_phrase: multi-token phrases on analyzed text fields (search string contains spaces, hyphens, commas, etc.).\n"
+    "- multi_match: when multiple analyzed text fields are equally relevant.\n"
+    "- term / terms: exact match on keyword, numeric, boolean.\n"
+    "- range: numeric/date comparisons (gt, lt, gte, lte).\n"
+    "- bool with must, should, must_not, filter: AND/OR/NOT logic.\n"
+    '- wildcard / prefix on keyword: "starts with" / pattern matching.\n'
+    "- exists: field presence/absence.\n"
+    '- nested query / nested agg: ONLY if the mapping for that exact path (or a parent) has "type":"nested".\n'
+    "- neural: semantic similarity on a 'semantic' or 'knn_vector' field (dense). "
+    'Use "query_text" and "k"; include "model_id" unless bound in mapping.\n'
+    "- neural (top-level): allowed when it's the only relevance clause needed; "
+    "otherwise wrap in a bool when combining with filters/other queries.\n"
+    "\n"
+    "Mechanics:\n"
+    "- Put exact constraints (term, terms, range, exists, prefix, wildcard) in bool.filter (non-scoring). "
+    "Put full-text relevance (match, match_phrase, multi_match) in bool.must.\n"
+    '- Top N items/products/documents: return top hits (set "size": N as an integer) and sort by the relevant metric(s). '
+    "Do not use aggregations for item lists.\n"
+    '- Neural retrieval size: set "k" >= "size" (e.g. heuristic, k = max(size*5, 100) and k<=ef_search).\n'
+    '- Spelling tolerance: match_phrase does NOT support fuzziness; use match or multi_match with "fuzziness": "AUTO" '
+    "when tolerant matching is needed.\n"
+    "- Text operators (OR vs AND): default to OR for natural-language queries; to tighten, use minimum_should_match "
+    '(e.g., "75%" requires ~75% of terms). Use AND only when every token is essential; if order/adjacency matters, '
+    "use match_phrase. (Applies to match/multi_match.)\n"
+    '- Numeric note: use ONLY integers for size and k (e.g., "size": 5), not floats (wrong e.g., "size": 5.0).\n'
+)
+
+AGGREGATION_RULES = (
+    "Aggregations (counts, averages, grouped summaries, distributions):\n"
+    "- Use aggregations when the user asks for grouped summaries (e.g., counts by category, averages by brand, "
+    "or top N categories/brands).\n"
+    "- terms on field.keyword or numeric for grouping / top N groups (not items).\n"
+    "- Metric aggs (avg, min, max, sum, stats, cardinality) on numeric fields.\n"
+    "- date_histogram, histogram, range for distributions.\n"
+    '- Always set "size": 0 when only aggregations are needed.\n'
+    '- Use sub-aggregations + order for "top N groups by metric".\n'
+    "- If grouping/filtering exactly on a text field, use its .keyword sub-field when present.\n"
+)
+
+SEMANTIC_SEARCH_RULES = (
+    "NEURAL / SEMANTIC SEARCH\n"
+    "When to use:\n"
+    '- The intent is conceptual/semantic ("about", "similar to", long phrases, synonyms, multilingual, ambiguous), '
+    "and the mapping has:\n"
+    '  - type: "semantic", or\n'
+    '  - type: "knn_vector".\n'
+    "- You also have exact filters (term/range/etc.) but text relevance still matters -> add neural on that text field.\n"
+    "- The user explicitly asks for semantic/neural/vector/embedding search.\n"
+    "When NOT to use:\n"
+    "- The request is purely structured/exact (IDs, codes, only term/range).\n"
+    '- No suitable "semantic" or "knn_vector" field exists.\n'
+    "- No Model ID found for neural search.\n"
+    "How to query:\n"
+    '- Use the "neural" clause against the chosen field.\n'
+    '- Required: "query_text" and "k".\n'
+    '- "model_id" rules:\n'
+    '  - For "semantic" fields, model usually bound in mapping -> omit unless overriding.\n'
+    '  - For "knn_vector", include "model_id" unless a default is bound elsewhere.\n'
+    "  - If model ID is not found, do not generate query with Neural clause.\n"
+    "Top-level usage:\n"
+    '- If there are no filters/other clauses, "neural" MAY be the root query (no bool).\n'
+    "- Use a bool wrapper only when combining with filters or additional queries; keep exact filters in bool.filter.\n"
+    "Sizing:\n"
+    '- "size": N is the returned hits.\n'
+    '- Set "k" >= "size" (heuristic: k (int) = max(size*5, 100), reasonable cap ~ 1000).\n'
+    "Field choice:\n"
+    "- Prefer a field that semantically represents intent (e.g., description/title/content).\n"
+    "- If multiple candidates exist, pick the single best; add more only if clearly beneficial.\n"
+    "Fallback:\n"
+    "- If no suitable neural field exists or if no model id is found, do NOT add a neural clause; "
+    "proceed with classic DSL or fall back to the default query if nothing relevant exists.\n"
+)
+
+DATE_RULES = (
+    "DATE RULES\n"
+    "- Use range on date/date_nanos in bool.filter.\n"
+    "- Emit ISO 8601 UTC ('Z') bounds; don't set time_zone for explicit UTC. (now is UTC)\n"
+    "- Date math: now+-N{y|M|w|d|h|m|s} (M=month, m=minute; e.g., now-7d .. now = last 7 days).\n"
+    '- Rounding: "/UNIT" floors to start (now/d, now/w, now/M, now/y). '
+    "Examples: last full day -> now-1d/d .. now/d; last full month -> now-1M/M .. now/M.\n"
+    "- End boundaries: prefer the next unit's start (avoid 23:59:59).\n"
+    '- Formats: only add "format" when inputs aren\'t default; epoch_millis allowed.\n'
+    "- Buckets: use date_histogram (set calendar_interval or fixed_interval); "
+    "add time_zone only when local day/week/month buckets are required.\n"
+)
+
+FIELD_SELECTION_AND_PROXYING = (
+    "Goal: pick the smallest set of mapping fields that best capture the user's intent.\n"
+    "Query Fields: when provided, and present in the mapping, prioritize using them; "
+    "ignore any that are not in the mapping.\n"
+    "Proxy Rule (mandatory): If at least one field is even loosely related to the intent, you MUST proceed using "
+    "the best available proxy fields. Do NOT fall back to the default query due to ambiguity.\n"
+    "Selection steps:\n"
+    "- Harvest candidates from the question (entities, attributes, constraints).\n"
+    "- From query_fields (that exist) and the index mapping, choose fields that map to those candidates and the "
+    "user intent, even if only loosely (use reasonable proxies).\n"
+    "- Ignore other fields that don't help answer the question.\n"
+    "- Micro Self-Check (silent): verify chosen fields exist; if any don't, swap to the closest mapped proxy and "
+    "continue. Only if no remotely relevant fields exist at all, use the default query.\n"
+)
+
+PROMPT_PREFIX = (
+    "==== PURPOSE ====\n"
+    "You are an OpenSearch DSL expert. Convert a natural-language question into a strict JSON OpenSearch query body.\n\n"
+    "==== RULES ====\n"
+    + QUERY_TYPE_RULES
+    + "\n"
+    + AGGREGATION_RULES
+    + "\n"
+    + DATE_RULES
+    + "\n"
+    + SEMANTIC_SEARCH_RULES
+    + "\n"
+    + "==== FIELD SELECTION & PROXYING ====\n"
+    + FIELD_SELECTION_AND_PROXYING
+)
+
+OUTPUT_FORMAT_INSTRUCTIONS = (
+    "==== OUTPUT FORMAT ====\n"
+    "- Put the OpenSearch request body (a single JSON object) in the `dsl` field of the EmitSearch tool call.\n"
+    "- Use valid JSON only: standard double quotes for all keys/strings; no comments; no trailing commas.\n"
+    "- In the `reason` field, briefly map each clause to the user's words.\n"
+    "- If the request truly cannot be fulfilled because no remotely relevant fields exist, set `dsl` to EXACTLY:\n"
+    + FALLBACK_DSL
+    + "\n"
+)
+
+EXAMPLE_1 = (
+    "Example 1 - numeric + date range (merged)\n"
+    "Input: Show all products that cost more than 50 dollars in the last 30 days.\n"
+    'Mapping: { "properties": { "price": { "type": "float" }, "created_at": { "type": "date" }, "color": { "type": "keyword" } } }\n'
+    "Query Fields: [price, created_at]\n"
+    "Field selection: relevant=[price(float), created_at(date)]; ignored=[color]\n"
+    'Output: { "query": { "bool": { "filter": [{ "range": { "price": { "gt": 50 } } }, { "range": { "created_at": { "gte": "now-30d/d", "lte": "now" } } } ] } } }\n'
+)
+
+EXAMPLE_2 = (
+    "Example 2 - text match + exact filter (spelling tolerant)\n"
+    "Input: Find employees in London who are active.\n"
+    'Mapping: { "properties": { "city": { "type": "text", "fields": { "keyword": { "type": "keyword" } } }, "status": { "type": "keyword" }, "notes": { "type": "text" } } }\n'
+    "Query Fields: [city, status]\n"
+    "Field selection: relevant=[city(text), status(keyword)]; ignored=[notes]\n"
+    'Output: { "query": { "bool": { "must": [ { "match": { "city": { "query": "London", "fuzziness": "AUTO" } } } ], "filter": [ { "term": { "status": "active" } } ] } } }\n'
+)
+
+EXAMPLE_3 = (
+    "Example 3 - match_phrase for multi-token\n"
+    "Input: Find employees located in New York City.\n"
+    'Mapping: { "properties": { "city": { "type": "text", "fields": { "keyword": { "type": "keyword" } } }, "department": { "type": "keyword" } } }\n'
+    'Output: { "query": { "match_phrase": { "city": "New York City" } } }\n'
+)
+
+EXAMPLE_4 = (
+    "Example 4 - multi_match across fields + SHOULD filters\n"
+    'Input: Find profiles mentioning "data engineering" in the title or summary that are research papers or blogs.\n'
+    'Mapping: { "properties": { "title": { "type": "text" }, "summary": { "type": "text" }, "type": { "type": "keyword" } } }\n'
+    'Output: { "query": { "bool": { "must": [ { "multi_match": { "query": "data engineering", "fields": ["title", "summary"], "fuzziness": "AUTO" } } ], "should": [ { "term": { "type": "research paper" } }, { "term": { "type": "blog" } } ], "minimum_should_match": 1 } } }\n'
+)
+
+EXAMPLE_5 = (
+    "Example 5 - wildcard + exists (exact filters in bool.filter)\n"
+    'Input: Find users whose email starts with "sam" and who have a phone number on file.\n'
+    'Mapping: { "properties": { "email": { "type": "keyword" }, "phone": { "type": "keyword" }, "avatar_url": { "type": "keyword" } } }\n'
+    "Field selection: relevant=[email(prefix), phone(exists)]; ignored=[avatar_url]\n"
+    'Output: { "query": { "bool": { "filter": [ { "prefix": { "email": "sam" } }, { "exists": { "field": "phone" } } ] } } }\n'
+)
+
+EXAMPLE_6 = (
+    "Example 6 - nested query (only when mapping says nested)\n"
+    "Input: Find books where an author's first_name is John AND last_name is Doe.\n"
+    'Mapping: { "properties": { "author": { "type": "nested", "properties": { "first_name": { "type": "text", "fields": { "keyword": { "type": "keyword" } } }, "last_name": { "type": "text", "fields": { "keyword": { "type": "keyword" } } } } }, "title": { "type": "text" } } }\n'
+    'Output: { "query": { "nested": { "path": "author", "query": { "bool": { "must": [ { "term": { "author.first_name.keyword": "John" } }, { "term": { "author.last_name.keyword": "Doe" } } ] } } } } }\n'
+)
+
+EXAMPLE_7 = (
+    "Example 7 - terms aggregation\n"
+    "Input: Show the number of orders per status.\n"
+    'Mapping: { "properties": { "status": { "type": "keyword" }, "order_id": { "type": "keyword" } } }\n'
+    'Output: { "size": 0, "aggs": { "orders_by_status": { "terms": { "field": "status" } } } }\n'
+)
+
+EXAMPLE_8 = (
+    "Example 8 - top N items by metric (hits + sort, no aggs)\n"
+    "Input: Show the 5 highest-rated electronics products.\n"
+    'Mapping: { "properties": { "category": { "type": "keyword" }, "rating": { "type": "float" }, "reviews_count": { "type": "integer" }, "product_name": { "type": "text" }, "description": { "type": "text" } } }\n'
+    "Field selection: relevant=[category(keyword), rating(float), reviews_count(integer), product_name(text), description(text)]\n"
+    'Output: { "size": 5, "query": { "bool": { "filter": [ { "term": { "category": "electronics" } } ] } }, "sort": [ { "rating": { "order": "desc" } }, { "reviews_count": { "order": "desc" } } ] }\n'
+)
+
+EXAMPLE_9 = (
+    "Example 9 - top N categories (grouping via aggs; not for item lists)\n"
+    "Input: List the top 3 categories by total sales volume.\n"
+    'Mapping: { "properties": { "category": { "type": "text", "fields": { "keyword": { "type": "keyword" } } }, "sales": { "type": "float" }, "region": { "type": "keyword" } } }\n'
+    "Field selection: relevant=[category.keyword, sales]; ignored=[region]\n"
+    'Output: { "size": 0, "aggs": { "top_categories": { "terms": { "field": "category.keyword", "size": 3, "order": { "total_sales": "desc" } }, "aggs": { "total_sales": { "sum": { "field": "sales" } } } } } }\n'
+)
+
+EXAMPLE_10 = (
+    "Example 10 - ambiguous mapping, proxy success\n"
+    "Input: Give medicines shipped from Vietnam.\n"
+    'Mapping: { "properties": { "item_name": { "type": "text" }, "product_category": { "type": "keyword" }, "country": { "type": "keyword" }, "ship_status": { "type": "keyword" }, "notes": { "type": "text" } } }\n'
+    "Query Fields: [product_category, origin_country]\n"
+    "Field selection: relevant=[product_category, country(proxy for origin), ship_status(proxy for shipped)]; ignored=[notes, item_name]\n"
+    'Output: { "query": { "bool": { "filter": [ { "term": { "product_category": "medicines" } }, { "term": { "country": "Vietnam" } }, { "term": { "ship_status": "shipped" } } ] } } }\n'
+)
+
+EXAMPLE_11 = (
+    "Example 11 - true fallback (no remotely relevant fields)\n"
+    "Input: List satellites with periapsis above 400km.\n"
+    'Mapping: { "properties": { "name": { "type": "text" }, "color": { "type": "keyword" } } }\n'
+    "Output: " + FALLBACK_DSL + "\n"
+)
+
+EXAMPLE_12 = (
+    "Example 12 - neural preferred with safe fallback (merged)\n"
+    'Input: Find articles about "LLM hallucinations". Model Id may or may not be provided.\n'
+    'Mapping: { "properties": { "content": {"type":"text"}, "content_vector": {"type":"knn_vector","dimension":768}, "tags": {"type":"keyword"}, "published_at": {"type":"date"} } }\n'
+    'Output (with model_id): { "size": 10, "query": { "neural": { "content_vector": { "query_text": "LLM hallucinations", "model_id": "m-dense-001", "k": 200 } } } }\n'
+    'Output (fallback without model_id): { "size": 10, "query": { "match": { "content": { "query": "LLM hallucinations" } } } }\n'
+)
+
+EXAMPLE_13 = (
+    "Example 13 - neural on semantic field + exact filters (mapping includes non-semantic fields)\n"
+    'Input: Find "wireless noise cancelling headphones with multipoint" under $200; brand Sony.\n'
+    'Mapping: { "properties": { "price": {"type":"float"}, "brand": {"type":"keyword"}, "title": {"type":"text"}, "description": {"type":"semantic", "model_id":"m-sem-123"} } }\n'
+    'Output: { "size": 10, "query": { "bool": { "must": [ { "neural": { "description": { "query_text": "wireless noise cancelling headphones with multipoint", "k": 120 } } } ], "filter": [ { "range": { "price": { "lte": 200 } } }, { "term": { "brand": "Sony" } } ] } } }\n'
+)
+
+EXAMPLES = (
+    "==== EXAMPLES ====\n"
+    + EXAMPLE_1
+    + EXAMPLE_2
+    + EXAMPLE_3
+    + EXAMPLE_4
+    + EXAMPLE_5
+    + EXAMPLE_6
+    + EXAMPLE_7
+    + EXAMPLE_8
+    + EXAMPLE_9
+    + EXAMPLE_10
+    + EXAMPLE_11
+    + EXAMPLE_12
+    + EXAMPLE_13
+)
+
+SYSTEM_PROMPT = PROMPT_PREFIX + "\n\n" + OUTPUT_FORMAT_INSTRUCTIONS + "\n" + EXAMPLES
+
+# Sent as content blocks with a trailing cache point so Bedrock caches the static
+# prefix (~5-minute TTL) and only the per-request tail (mapping + question, in the
+# user message) is billed on warm calls. The cache point is a no-op off Bedrock.
+SYSTEM_BLOCKS: list[SystemContentBlock] = [
+    {"text": SYSTEM_PROMPT},
+    {"cachePoint": {"type": "default"}},
+]
+
+USER_PROMPT = """\
+Question: {question}
+Index: {index_name}
+Mapping: {mapping}
+
+Emit the OpenSearch _search body for this question.
+"""

--- a/src/agents/agentic_search/prompts/__init__.py
+++ b/src/agents/agentic_search/prompts/__init__.py
@@ -1,0 +1,15 @@
+"""Prompts for the agentic-search agent, split by generation strategy.
+
+- :mod:`.direct_dsl` — rules, examples, ``EmitSearch`` schema, and cached system
+  blocks for free-DSL generation (the default strategy).
+
+Strategies import their own prompt set from the submodule directly. Only
+``FALLBACK_DSL`` is re-exported here, since the agent shell returns it on any
+generation failure regardless of strategy.
+"""
+
+from __future__ import annotations
+
+from agents.agentic_search.prompts.direct_dsl import FALLBACK_DSL
+
+__all__ = ["FALLBACK_DSL"]

--- a/src/agents/agentic_search/prompts/direct_dsl.py
+++ b/src/agents/agentic_search/prompts/direct_dsl.py
@@ -2,8 +2,8 @@
 
 The system prompt is a large, static rules-and-examples prefix. It is sent as
 Bedrock content blocks with a trailing cache point so it is served from cache on
-warm calls (Bedrock only; harmlessly ignored elsewhere); the per-request mapping
-and question go in the user message, after the cached prefix.
+warm calls (Bedrock only; harmlessly ignored elsewhere); the per-request mapping,
+sample document, and question go in the user message, after the cached prefix.
 """
 
 from __future__ import annotations
@@ -287,17 +287,20 @@ EXAMPLES = (
 SYSTEM_PROMPT = PROMPT_PREFIX + "\n\n" + OUTPUT_FORMAT_INSTRUCTIONS + "\n" + EXAMPLES
 
 # Sent as content blocks with a trailing cache point so Bedrock caches the static
-# prefix (~5-minute TTL) and only the per-request tail (mapping + question, in the
-# user message) is billed on warm calls. The cache point is a no-op off Bedrock.
+# prefix (~5-minute TTL) and only the per-request tail (mapping + sample + question,
+# in the user message) is billed on warm calls. The cache point is a no-op off Bedrock.
 SYSTEM_BLOCKS: list[SystemContentBlock] = [
     {"text": SYSTEM_PROMPT},
     {"cachePoint": {"type": "default"}},
 ]
 
+# The mapping gives field types; the sample document adds one real indexed doc so
+# the model can see actual field values (e.g. exact keyword/enum values), not just types.
 USER_PROMPT = """\
 Question: {question}
 Index: {index_name}
 Mapping: {mapping}
+Sample document from index: {sample_document}
 
 Emit the OpenSearch _search body for this question.
 """

--- a/src/agents/agentic_search/strategies/__init__.py
+++ b/src/agents/agentic_search/strategies/__init__.py
@@ -1,0 +1,16 @@
+"""Generation strategies, selected per request by ``context["strategy"]``.
+
+Each strategy turns a natural-language question into an OpenSearch ``_search``
+body; the agent (``agent.py``) owns the shared plumbing (cluster client, model,
+credentials, fallback) and dispatches here. To add one — e.g. search-template
+fill — write its module and register it in ``STRATEGIES``; nothing else changes.
+"""
+
+from __future__ import annotations
+
+from agents.agentic_search.strategies.direct_dsl import DirectDslStrategy
+
+# Registry keyed by strategy name. `direct_dsl` is the default when a request
+# omits `context.strategy`.
+STRATEGIES = {DirectDslStrategy.name: DirectDslStrategy()}
+DEFAULT_STRATEGY = DirectDslStrategy.name

--- a/src/agents/agentic_search/strategies/base.py
+++ b/src/agents/agentic_search/strategies/base.py
@@ -1,0 +1,43 @@
+"""The generation-strategy contract for the agentic-search agent.
+
+A strategy turns a natural-language question into an OpenSearch ``_search`` body
+(a dict). The agent owns the shared plumbing (cluster client, model, credentials,
+fallback) and passes it to the strategy as a :class:`GenerationRequest`; the
+strategy is selected per request by ``context["strategy"]``. New generation
+methods (e.g. search-template fill) are new modules registered in
+``strategies/__init__.py`` — adding one means adding code, not editing this
+contract. A generator whose output is not a ``_search`` body (e.g. a PPL or
+intermediate-representation generator) belongs in a sibling agent, not here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from opensearchpy import OpenSearch
+
+
+@dataclass(frozen=True)
+class GenerationRequest:
+    """Everything a strategy needs to generate a ``_search`` body.
+
+    Bundled so a new shared input can be added here without touching every
+    strategy's signature. Strategy-specific inputs travel in ``context``.
+    """
+
+    question: str
+    index_name: str
+    mapping: str
+    context: dict[str, Any]
+    model: Any
+    client: OpenSearch
+
+
+class GenerationStrategy(Protocol):
+    """Returns a ``_search`` body dict; raising degrades the request to the fallback."""
+
+    name: str
+
+    def generate(self, request: GenerationRequest) -> dict[str, Any]: ...

--- a/src/agents/agentic_search/strategies/direct_dsl.py
+++ b/src/agents/agentic_search/strategies/direct_dsl.py
@@ -1,55 +1,87 @@
 """Direct-DSL generation: the model authors the whole ``_search`` body.
 
-The default (and today's only) generation strategy. It hands the LLM the index
-mapping and prompts it, via a single forced ``EmitSearch`` tool call, to write a
-complete OpenSearch query body. Future strategies (e.g. search-template fill)
-are sibling modules registered alongside this one.
+The default generation strategy. It gives the model the index mapping and one
+sample document, then has it author a complete OpenSearch query body via a single
+forced tool call (see :func:`forced_tool_fill`):
+
+- The forced tool call keeps the model's ``EmitSearch`` rationale inside the tool
+  input rather than as leading free text.
+- The sample document supplies real field values (e.g. exact keyword/enum values),
+  which the mapping alone does not, helping the model choose the right field and term.
 """
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any
 
-from strands import Agent
-
-from agents.agentic_search.prompts import (
+from agents.agentic_search.prompts.direct_dsl import (
     SYSTEM_BLOCKS,
     USER_PROMPT,
     EmitSearch,
 )
 from agents.agentic_search.strategies.base import GenerationRequest
+from agents.agentic_search.strategies.forced_tool import forced_tool_fill
 
 logger = logging.getLogger(__name__)
 
+# Cap each sample-doc field value to this many chars so a large text field can't
+# dominate the prompt.
+_MAX_TRUNCATE_CHARS = 250
+
+
+def _fetch_sample_document(client: Any, index_name: str) -> str:
+    """Fetch one indexed document with field values truncated.
+
+    Returns a JSON string, or ``""`` on any failure. The sample document is
+    best-effort enrichment, so an empty index or a search error is non-fatal.
+    """
+    try:
+        resp = client.search(
+            index=index_name,
+            body={"size": 1, "query": {"match_all": {}}, "sort": ["_doc"]},
+            _source=True,
+        )
+        hits = resp.get("hits", {}).get("hits", [])
+        if not hits:
+            return ""
+        source = hits[0].get("_source", {})
+        truncated = {
+            k: (v[:_MAX_TRUNCATE_CHARS] if isinstance(v, str) else v)
+            for k, v in source.items()
+        }
+        return json.dumps(truncated)
+    except Exception:  # noqa: BLE001 - best-effort; proceed without a sample
+        logger.warning("Sample document fetch failed for index=%s; proceeding without", index_name)
+        return ""
+
 
 class DirectDslStrategy:
-    """Generate a ``_search`` body directly from the NLQ and index mapping."""
+    """Generate a ``_search`` body directly from the NLQ, index mapping, and a sample doc."""
 
     name = "direct_dsl"
 
     def generate(self, request: GenerationRequest) -> dict[str, Any]:
         """Return the OpenSearch ``_search`` body as a dict for the NLQ.
 
-        A fresh ``Agent`` per call keeps each request stateless; the shared
-        ``request.model`` carries the cost-bearing connection. The system prompt
-        is passed as content blocks so its cache point reaches the request, and
-        the non-deprecated ``structured_output_model`` invocation is required —
-        the older ``structured_output()`` flattens the prompt to a string and
-        drops the cache point.
+        ``SYSTEM_BLOCKS`` carries the rules and examples behind a cache point, so on
+        warm calls only the per-request tail (mapping, sample document, question) is
+        billed.
         """
-        agent = Agent(
-            model=request.model,
-            system_prompt=SYSTEM_BLOCKS,
-            tools=[],
-            callback_handler=None,
-        )
+        sample = _fetch_sample_document(request.client, request.index_name)
         user_msg = USER_PROMPT.format(
             question=request.question,
             index_name=request.index_name,
             mapping=request.mapping,
+            sample_document=sample or "(none available)",
         )
-        result = agent(user_msg, structured_output_model=EmitSearch).structured_output
+        result = forced_tool_fill(
+            model=request.model,
+            schema_model=EmitSearch,
+            system_blocks=SYSTEM_BLOCKS,
+            user_message=user_msg,
+        )
         logger.info(
             "Generated DSL for index=%s (reason=%s)", request.index_name, result.reason
         )

--- a/src/agents/agentic_search/strategies/direct_dsl.py
+++ b/src/agents/agentic_search/strategies/direct_dsl.py
@@ -1,0 +1,56 @@
+"""Direct-DSL generation: the model authors the whole ``_search`` body.
+
+The default (and today's only) generation strategy. It hands the LLM the index
+mapping and prompts it, via a single forced ``EmitSearch`` tool call, to write a
+complete OpenSearch query body. Future strategies (e.g. search-template fill)
+are sibling modules registered alongside this one.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from strands import Agent
+
+from agents.agentic_search.prompts import (
+    SYSTEM_BLOCKS,
+    USER_PROMPT,
+    EmitSearch,
+)
+from agents.agentic_search.strategies.base import GenerationRequest
+
+logger = logging.getLogger(__name__)
+
+
+class DirectDslStrategy:
+    """Generate a ``_search`` body directly from the NLQ and index mapping."""
+
+    name = "direct_dsl"
+
+    def generate(self, request: GenerationRequest) -> dict[str, Any]:
+        """Return the OpenSearch ``_search`` body as a dict for the NLQ.
+
+        A fresh ``Agent`` per call keeps each request stateless; the shared
+        ``request.model`` carries the cost-bearing connection. The system prompt
+        is passed as content blocks so its cache point reaches the request, and
+        the non-deprecated ``structured_output_model`` invocation is required —
+        the older ``structured_output()`` flattens the prompt to a string and
+        drops the cache point.
+        """
+        agent = Agent(
+            model=request.model,
+            system_prompt=SYSTEM_BLOCKS,
+            tools=[],
+            callback_handler=None,
+        )
+        user_msg = USER_PROMPT.format(
+            question=request.question,
+            index_name=request.index_name,
+            mapping=request.mapping,
+        )
+        result = agent(user_msg, structured_output_model=EmitSearch).structured_output
+        logger.info(
+            "Generated DSL for index=%s (reason=%s)", request.index_name, result.reason
+        )
+        return result.dsl

--- a/src/agents/agentic_search/strategies/direct_dsl.py
+++ b/src/agents/agentic_search/strategies/direct_dsl.py
@@ -1,11 +1,12 @@
 """Direct-DSL generation: the model authors the whole ``_search`` body.
 
 The default generation strategy. It gives the model the index mapping and one
-sample document, then has it author a complete OpenSearch query body via a single
-forced tool call (see :func:`forced_tool_fill`):
+sample document, then has it author a complete OpenSearch query body:
 
-- The forced tool call keeps the model's ``EmitSearch`` rationale inside the tool
-  input rather than as leading free text.
+- On Bedrock, a single forced tool call (see :func:`forced_tool_fill`) keeps the
+  model's ``EmitSearch`` rationale inside the tool input rather than as leading
+  free text. Other providers (e.g. Ollama) use the portable strands
+  ``structured_output`` path, which does not support forcing ``toolChoice``.
 - The sample document supplies real field values (e.g. exact keyword/enum values),
   which the mapping alone does not, helping the model choose the right field and term.
 """
@@ -16,13 +17,18 @@ import json
 import logging
 from typing import Any
 
+from strands import Agent
+
 from agents.agentic_search.prompts.direct_dsl import (
     SYSTEM_BLOCKS,
     USER_PROMPT,
     EmitSearch,
 )
 from agents.agentic_search.strategies.base import GenerationRequest
-from agents.agentic_search.strategies.forced_tool import forced_tool_fill
+from agents.agentic_search.strategies.forced_tool import (
+    forced_tool_fill,
+    supports_forced_tool,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -67,7 +73,8 @@ class DirectDslStrategy:
 
         ``SYSTEM_BLOCKS`` carries the rules and examples behind a cache point, so on
         warm calls only the per-request tail (mapping, sample document, question) is
-        billed.
+        billed. Uses the forced-tool path on Bedrock and the portable strands
+        ``structured_output`` path elsewhere.
         """
         sample = _fetch_sample_document(request.client, request.index_name)
         user_msg = USER_PROMPT.format(
@@ -76,13 +83,31 @@ class DirectDslStrategy:
             mapping=request.mapping,
             sample_document=sample or "(none available)",
         )
-        result = forced_tool_fill(
-            model=request.model,
-            schema_model=EmitSearch,
-            system_blocks=SYSTEM_BLOCKS,
-            user_message=user_msg,
-        )
+        result = self._emit(request.model, user_msg)
         logger.info(
             "Generated DSL for index=%s (reason=%s)", request.index_name, result.reason
         )
         return result.dsl
+
+    @staticmethod
+    def _emit(model: Any, user_msg: str) -> EmitSearch:
+        """Produce the ``EmitSearch`` result, using the best path for the provider.
+
+        Bedrock forces the tool call (no leading free text); other providers fall
+        back to the portable strands ``structured_output`` path, which handles the
+        provider differences but cannot force ``toolChoice``.
+        """
+        if supports_forced_tool(model):
+            return forced_tool_fill(
+                model=model,
+                schema_model=EmitSearch,
+                system_blocks=SYSTEM_BLOCKS,
+                user_message=user_msg,
+            )
+        agent = Agent(
+            model=model,
+            system_prompt=SYSTEM_BLOCKS,
+            tools=[],
+            callback_handler=None,
+        )
+        return agent(user_msg, structured_output_model=EmitSearch).structured_output

--- a/src/agents/agentic_search/strategies/forced_tool.py
+++ b/src/agents/agentic_search/strategies/forced_tool.py
@@ -5,6 +5,15 @@ the tool call immediately, with no leading free text. The high-level strands
 ``Agent`` API does not expose ``toolChoice``, so the call is driven directly; this
 also means the SDK's automatic retry-on-non-tool-response is not available, so an
 empty or malformed tool call raises ``ValueError`` for the caller to handle.
+
+This is a workaround. It is Bedrock-specific — it uses the botocore
+``converse_stream`` client directly — so callers must gate it with
+:func:`supports_forced_tool` and use the portable strands ``structured_output``
+path for other providers (e.g. Ollama). It can be removed once strands exposes
+``tool_choice`` on ``structured_output``.
+
+Tracking: https://github.com/opensearch-project/opensearch-agent-server/issues/149
+Upstream: https://github.com/strands-agents/harness-sdk/issues/3336
 """
 
 from __future__ import annotations
@@ -16,6 +25,17 @@ from pydantic import BaseModel, ValidationError
 from strands.tools.structured_output import convert_pydantic_to_tool_spec
 
 logger = logging.getLogger(__name__)
+
+
+def supports_forced_tool(model: Any) -> bool:
+    """Whether ``model`` supports the forced-tool path (Bedrock ``converse_stream``).
+
+    Only Bedrock models expose the botocore ``converse_stream`` client this path
+    drives directly. Other providers (e.g. Ollama) must use the portable strands
+    ``structured_output`` path instead.
+    """
+    client = getattr(model, "client", None)
+    return client is not None and hasattr(client, "converse_stream")
 
 
 def forced_tool_fill(

--- a/src/agents/agentic_search/strategies/forced_tool.py
+++ b/src/agents/agentic_search/strategies/forced_tool.py
@@ -1,0 +1,91 @@
+"""Forced tool-call generation over Bedrock ``converse_stream``.
+
+Registers a Pydantic model as a tool and forces ``toolChoice`` so the model emits
+the tool call immediately, with no leading free text. The high-level strands
+``Agent`` API does not expose ``toolChoice``, so the call is driven directly; this
+also means the SDK's automatic retry-on-non-tool-response is not available, so an
+empty or malformed tool call raises ``ValueError`` for the caller to handle.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pydantic import BaseModel, ValidationError
+from strands.tools.structured_output import convert_pydantic_to_tool_spec
+
+logger = logging.getLogger(__name__)
+
+
+def forced_tool_fill(
+    *,
+    model: Any,
+    schema_model: type[BaseModel],
+    system_blocks: list[dict],
+    user_message: str,
+    tool_spec: dict[str, Any] | None = None,
+) -> BaseModel:
+    """Force a single tool call for ``schema_model`` and return the validated instance.
+
+    Args:
+        model: The shared strands ``BedrockModel``; its pooled botocore client
+            (``model.client``) and ``model.config`` (``model_id``, optional
+            ``temperature``) drive the call directly.
+        schema_model: The Pydantic model registered as the forced tool. Its
+            validated instance is returned.
+        system_blocks: Bedrock system content blocks (may carry a cache point);
+            copied defensively before sending.
+        user_message: The user turn's text.
+        tool_spec: Optional precomputed ``convert_pydantic_to_tool_spec`` result.
+            When ``None`` it is computed from ``schema_model`` here.
+
+    Returns:
+        The validated ``schema_model`` instance.
+
+    Raises:
+        ValueError: The forced tool produced no input, or the input failed
+            validation against ``schema_model``.
+    """
+    spec = tool_spec if tool_spec is not None else convert_pydantic_to_tool_spec(schema_model)
+    tool_name = spec["name"]
+
+    client = model.client  # botocore bedrock-runtime client (pooled connection)
+    converse_kwargs: dict[str, Any] = {
+        "modelId": model.config.get("model_id"),
+        "system": [dict(b) for b in system_blocks],
+        "messages": [{"role": "user", "content": [{"text": user_message}]}],
+        "toolConfig": {
+            "tools": [
+                {
+                    "toolSpec": {
+                        "name": tool_name,
+                        "description": spec.get("description", "Emit the result."),
+                        "inputSchema": spec["inputSchema"],
+                    }
+                }
+            ],
+            "toolChoice": {"tool": {"name": tool_name}},
+        },
+    }
+    # Driving converse_stream directly bypasses the strands request builder, so
+    # apply the model's configured temperature here if one is set.
+    temperature = model.config.get("temperature")
+    if temperature is not None:
+        converse_kwargs["inferenceConfig"] = {"temperature": temperature}
+
+    resp = client.converse_stream(**converse_kwargs)
+
+    # Accumulate the forced tool's input JSON from the stream.
+    tool_input = ""
+    for event in resp["stream"]:
+        tool_use = event.get("contentBlockDelta", {}).get("delta", {}).get("toolUse")
+        if tool_use and "input" in tool_use:
+            tool_input += tool_use["input"]
+
+    if not tool_input.strip():
+        raise ValueError("forced tool call produced no input")
+    try:
+        return schema_model.model_validate_json(tool_input)
+    except ValidationError as e:
+        raise ValueError(f"forced tool input failed validation: {e}") from e

--- a/src/server/ag_ui_app.py
+++ b/src/server/ag_ui_app.py
@@ -66,6 +66,7 @@ from server.rate_limiting import (  # noqa: E402
     setup_rate_limiting,
 )
 from server.request_id_middleware import RequestIdMiddleware  # noqa: E402
+from server.response_formats import wrap_inference_results  # noqa: E402
 from server.run_routes import (  # noqa: E402
     _extract_auth_headers,
     cancel_run_route,
@@ -73,6 +74,7 @@ from server.run_routes import (  # noqa: E402
     get_run_events_route,
     get_run_route,
 )
+
 
 def _init_tracing() -> None:
     """Initialize OpenTelemetry tracing.
@@ -395,6 +397,20 @@ def create_app(config_override: ServerConfig | None = None) -> FastAPI:
             "ag_ui.art_agent_factory_ready",
         )
 
+        # Register the agentic-search agent (NLQ->DSL), reachable via POST /invoke.
+        from agents.agentic_search import create_agentic_search_agent
+
+        orchestrator.register_agent_factory(
+            name="agentic_search",
+            factory=lambda: create_agentic_search_agent(opensearch_url),
+            description="Natural-language query to OpenSearch DSL (non-streaming, via /invoke)",
+        )
+        log_info_event(
+            logger,
+            "✓ agentic_search agent registered (POST /invoke)",
+            "ag_ui.agentic_search_ready",
+        )
+
         yield
 
     app = FastAPI(
@@ -646,27 +662,55 @@ async def invoke(
     Runs the agent to completion and returns the final response as JSON.
     Accepts a string query or message list (Strands Agent interface).
     """
-    body = await request.json()
-    query = body.get("query")
-    messages = body.get("messages")
-    agent_name = body.get("agent")
-    timeout = body.get("timeout", 600)
-
-    if not query and not messages:
+    def _bad_request(message: str) -> JSONResponse:
         return JSONResponse(
             status_code=400,
             content={
-                "error": "Request must include 'query' or 'messages'.",
+                "error": message,
                 "error_type": "ValidationError",
                 "status": "error",
             },
         )
 
+    try:
+        body = await request.json()
+    except (json.JSONDecodeError, ValueError):
+        return _bad_request("Request body must be valid JSON.")
+    if not isinstance(body, dict):
+        return _bad_request("Request body must be a JSON object.")
+
+    query = body.get("query")
+    messages = body.get("messages")
+    agent_name = body.get("agent")
+    timeout = body.get("timeout", 600)
+    # Generic extensions: `context` is structured input forwarded verbatim to
+    # context-aware agents (e.g. DSL generation reads `index_name` from it);
+    # `response_format` opts into the ml-commons inference_results envelope so an
+    # ml-commons connector's passthrough can consume the reply. Both default to
+    # today's behavior, so existing callers are unaffected.
+    context = body.get("context")
+    response_format = body.get("response_format")
+
+    if not query and not messages:
+        return _bad_request("Request must include 'query' or 'messages'.")
+    if context is not None and not isinstance(context, dict):
+        return _bad_request("'context' must be a JSON object.")
+
     if messages:
+        if not isinstance(messages, list) or not all(
+            isinstance(m, dict) and isinstance(m.get("role"), str)
+            and isinstance(m.get("content"), str)
+            for m in messages
+        ):
+            return _bad_request(
+                "'messages' must be a list of {role: str, content: str} objects."
+            )
         prompt: str | list[dict] = [
             {"role": m["role"], "content": [{"text": m["content"]}]}
             for m in messages
         ]
+    elif not isinstance(query, str):
+        return _bad_request("'query' must be a string.")
     else:
         prompt = query
 
@@ -678,7 +722,10 @@ async def invoke(
             agent_name=agent_name,
             headers=forwarded_headers,
             timeout=timeout,
+            context=context,
         )
+        if response_format == "inference_results":
+            return JSONResponse(content=wrap_inference_results(response_text))
         return JSONResponse(content={"response": response_text, "status": "success"})
     except TimeoutError as e:
         return JSONResponse(
@@ -704,6 +751,7 @@ async def invoke(
                 "status": "error",
             },
         )
+
 
 if __name__ == "__main__":
     import uvicorn

--- a/src/server/agent_orchestrator.py
+++ b/src/server/agent_orchestrator.py
@@ -221,6 +221,7 @@ class AgentOrchestrator:
         agent_name: str | None = None,
         headers: dict[str, str] | None = None,
         timeout: float = 600,
+        context: dict[str, Any] | None = None,
     ) -> str:
         """Invoke an agent synchronously and return the final response.
 
@@ -232,6 +233,9 @@ class AgentOrchestrator:
             agent_name: Explicit agent name. If ``None``, uses the default agent.
             headers: Optional HTTP headers forwarded from the request.
             timeout: Maximum seconds to wait for the agent to complete.
+            context: Optional structured input forwarded verbatim to agents that
+                declare ``accepts_invoke_context`` (e.g. DSL generation, which
+                reads ``index_name`` from it). Ordinary Strands agents ignore it.
 
         Returns:
             The agent's final response as a string.
@@ -266,12 +270,22 @@ class AgentOrchestrator:
             timeout=timeout,
         )
 
+        # Context-aware agents (e.g. DSL generation) opt in to receive the
+        # structured `context` and the forwarded bearer token. Ordinary Strands
+        # agents take only the prompt, so `context` never reaches them.
+        if getattr(agent, "accepts_invoke_context", False):
+            call = lambda: agent(prompt, context=context or {}, auth_token=token)  # noqa: E731
+        else:
+            call = lambda: agent(prompt)  # noqa: E731
+
         try:
             result = await asyncio.wait_for(
-                asyncio.to_thread(agent, prompt),
+                asyncio.to_thread(call),
                 timeout=timeout,
             )
-            return str(result) if result else ""
+            # Only a missing result is empty; falsey-but-valid values (0, False)
+            # are still stringified.
+            return str(result) if result is not None else ""
         except asyncio.TimeoutError:
             agent.cancel()
             raise TimeoutError(

--- a/src/server/response_formats.py
+++ b/src/server/response_formats.py
@@ -1,0 +1,26 @@
+"""Optional ``/invoke`` response envelopes, selected by the ``response_format`` field.
+
+These shape *any* agent's string reply for a specific consumer; they are not tied
+to a particular agent. Today the only envelope is ml-commons' ``inference_results``
+passthrough shape, used by the agentic-search connector.
+"""
+
+from __future__ import annotations
+
+from server.types import InferenceResultsResponse
+
+
+def wrap_inference_results(result: str) -> InferenceResultsResponse:
+    """Wrap an agent's string reply in the ml-commons inference_results envelope.
+
+    A connector's built-in ``mlcommons.passthrough`` post-processor copies
+    ``output[0].result`` into ``ModelTensor.result`` (the field neural-search reads).
+    """
+    return {
+        "inference_results": [
+            {
+                "output": [{"name": "response", "result": result}],
+                "status_code": 200,
+            }
+        ]
+    }

--- a/src/server/types.py
+++ b/src/server/types.py
@@ -476,3 +476,19 @@ class CancelRunResponse(TypedDict):
     runId: str
     canceled: bool
     message: str
+
+
+class InferenceResultsResponse(TypedDict):
+    """ml-commons ``inference_results`` envelope returned by ``/invoke``.
+
+    Used when a caller sets ``response_format=inference_results`` (e.g. the
+    agentic-search connector). A connector's built-in passthrough post-processor
+    copies ``output[0].result`` into ``ModelTensor.result``.
+
+    Attributes:
+        inference_results: One result whose ``output[0].result`` is the agent's
+            reply (for the ``agentic_search`` agent, the DSL query) as a string.
+
+    """
+
+    inference_results: list[dict[str, Any]]

--- a/src/utils/model_factory.py
+++ b/src/utils/model_factory.py
@@ -74,6 +74,16 @@ def create_model(*, tier: str = "default"):
             or _DEFAULT_BEDROCK_MODEL_ID
         )
 
+    # Optional temperature override via LLM_TEMPERATURE. Unset leaves Bedrock's
+    # default sampling.
+    _temp_env = os.getenv("LLM_TEMPERATURE")
+    extra: dict = {}
+    if _temp_env is not None:
+        try:
+            extra["temperature"] = float(_temp_env)
+        except ValueError:
+            pass
+
     log_info_event(
         logger,
         f"Creating BedrockModel (tier={tier}, model={model_id})",
@@ -85,4 +95,5 @@ def create_model(*, tier: str = "default"):
         model_id=model_id,
         boto_session=boto3.Session(),
         streaming=True,
+        **extra,
     )

--- a/tests/unit/test_agentic_search_agent.py
+++ b/tests/unit/test_agentic_search_agent.py
@@ -1,0 +1,139 @@
+"""Unit tests for the agentic_search agent (reached via POST /invoke).
+
+The OpenSearch client and the generation strategy are stubbed, so nothing hits a
+cluster or an LLM. Covers: strategy dispatch and mapping/token plumbing, the
+guard paths (bad query / missing index / unknown strategy / non-dict result),
+and that every failure degrades to FALLBACK_DSL.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agents.agentic_search import agent as agent_module
+from agents.agentic_search.agent import AgenticSearchAgent
+from agents.agentic_search.prompts import FALLBACK_DSL
+
+pytestmark = pytest.mark.unit
+
+MATCH_ALL = {"size": 10, "query": {"match_all": {}}}
+
+
+class _StubStrategy:
+    """Records the generate() call and returns a canned body (or raises)."""
+
+    name = "direct_dsl"
+
+    def __init__(self, *, returns=None, raises=None):
+        self._returns = returns if returns is not None else {"query": {"match_all": {}}}
+        self._raises = raises
+        self.calls = []
+
+    def generate(self, request):
+        self.calls.append(request)
+        if self._raises is not None:
+            raise self._raises
+        return self._returns
+
+
+class _StubClient:
+    """Stands in for the OpenSearch client; records the mapping fetch."""
+
+    def __init__(self, mapping=None):
+        self._mapping = mapping if mapping is not None else {"products": {"mappings": {}}}
+        self.fetched = []
+
+    class _Indices:
+        def __init__(self, outer):
+            self._outer = outer
+
+        def get_mapping(self, index):
+            self._outer.fetched.append(index)
+            return self._outer._mapping
+
+    @property
+    def indices(self):
+        return _StubClient._Indices(self)
+
+
+@pytest.fixture
+def make_agent(monkeypatch):
+    """Build an AgenticSearchAgent with model creation + client stubbed out."""
+
+    def _factory(strategy=None, client=None):
+        monkeypatch.setattr(agent_module, "create_model", lambda: object())
+        strat = strategy or _StubStrategy()
+        monkeypatch.setattr(agent_module, "STRATEGIES", {strat.name: strat})
+        monkeypatch.setattr(agent_module, "DEFAULT_STRATEGY", strat.name)
+        a = AgenticSearchAgent("http://localhost:9200")
+        monkeypatch.setattr(a, "_client", lambda auth_token: client or _StubClient())
+        return a, strat
+
+    return _factory
+
+
+def test_happy_path_dispatches_and_returns_dsl(make_agent):
+    strat = _StubStrategy(returns={"query": {"term": {"color": "red"}}})
+    client = _StubClient(mapping={"products": {"mappings": {"properties": {}}}})
+    a, strat = make_agent(strategy=strat, client=client)
+
+    out = a("red shoes", context={"index_name": "products"}, auth_token="tok")
+
+    assert json.loads(out) == {"query": {"term": {"color": "red"}}}
+    # mapping fetched for the requested index; strategy got a GenerationRequest
+    # carrying the NLQ, mapping, context, model, and client.
+    assert client.fetched == ["products"]
+    req = strat.calls[0]
+    assert req.question == "red shoes" and req.index_name == "products"
+    assert json.loads(req.mapping) == {"products": {"mappings": {"properties": {}}}}
+    assert req.context == {"index_name": "products"}
+    assert req.client is client and req.model is not None
+
+
+def test_declares_context_awareness():
+    # The orchestrator keys context/auth forwarding off this flag.
+    assert AgenticSearchAgent.accepts_invoke_context is True
+
+
+def test_missing_index_name_falls_back(make_agent):
+    a, strat = make_agent()
+    assert a("red shoes", context={}) == FALLBACK_DSL
+    assert strat.calls == []  # guarded before reaching the strategy
+
+
+def test_empty_query_falls_back(make_agent):
+    a, strat = make_agent()
+    assert a("   ", context={"index_name": "products"}) == FALLBACK_DSL
+    assert strat.calls == []
+
+
+def test_non_string_query_falls_back(make_agent):
+    a, strat = make_agent()
+    assert a(["not", "a", "string"], context={"index_name": "products"}) == FALLBACK_DSL
+    assert strat.calls == []
+
+
+def test_non_dict_context_falls_back(make_agent):
+    a, strat = make_agent()
+    assert a("red shoes", context="oops") == FALLBACK_DSL
+    assert strat.calls == []
+
+
+def test_unknown_strategy_falls_back(make_agent):
+    a, strat = make_agent()
+    out = a("red shoes", context={"index_name": "products", "strategy": "nope"})
+    assert out == FALLBACK_DSL
+    assert strat.calls == []
+
+
+def test_strategy_exception_falls_back(make_agent):
+    a, strat = make_agent(strategy=_StubStrategy(raises=RuntimeError("bedrock down")))
+    assert a("red shoes", context={"index_name": "products"}) == FALLBACK_DSL
+
+
+def test_non_object_strategy_result_falls_back(make_agent):
+    # A strategy must return a _search body object; anything else degrades.
+    a, strat = make_agent(strategy=_StubStrategy(returns=["not", "an", "object"]))
+    assert a("red shoes", context={"index_name": "products"}) == FALLBACK_DSL

--- a/tests/unit/test_direct_dsl_strategy.py
+++ b/tests/unit/test_direct_dsl_strategy.py
@@ -1,0 +1,109 @@
+"""Unit tests for the direct_dsl strategy's provider routing.
+
+The forced-tool path is Bedrock-specific (drives ``converse_stream`` directly),
+so the strategy must fall back to the portable strands ``structured_output`` path
+for other providers (e.g. Ollama). These tests stub both paths — nothing hits a
+cluster or an LLM — and assert the right one is chosen per provider.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agents.agentic_search.strategies import direct_dsl as direct_dsl_module
+from agents.agentic_search.strategies.direct_dsl import DirectDslStrategy
+from agents.agentic_search.strategies.forced_tool import supports_forced_tool
+
+pytestmark = pytest.mark.unit
+
+
+class _BedrockLikeModel:
+    """Has a ``client`` exposing ``converse_stream`` (the forced-tool capability)."""
+
+    class _Client:
+        def converse_stream(self, **kwargs):  # pragma: no cover - never called (stubbed)
+            raise AssertionError("real converse_stream should be stubbed out")
+
+    client = _Client()
+    config = {"model_id": "bedrock-model"}
+
+
+class _OllamaLikeModel:
+    """No ``converse_stream`` on its client — must use the portable path."""
+
+    class _Client:
+        pass
+
+    client = _Client()
+    config = {"model_id": "ollama-model"}
+
+
+class _StubClient:
+    """OpenSearch client stub for the sample-document fetch."""
+
+    def search(self, index, body, _source):
+        return {"hits": {"hits": [{"_source": {"title": "Widget", "color": "red"}}]}}
+
+
+class _Request:
+    def __init__(self, model):
+        self.model = model
+        self.client = _StubClient()
+        self.question = "red widgets"
+        self.index_name = "products"
+        self.mapping = '{"properties": {"color": {"type": "keyword"}}}'
+        self.context: dict = {}
+
+
+class _Result:
+    reason = "match color=red"
+    dsl = {"query": {"term": {"color": "red"}}}
+
+
+def test_supports_forced_tool_detects_bedrock_vs_ollama():
+    assert supports_forced_tool(_BedrockLikeModel()) is True
+    assert supports_forced_tool(_OllamaLikeModel()) is False
+    assert supports_forced_tool(object()) is False  # no client attribute
+
+
+def test_bedrock_uses_forced_tool_path(monkeypatch):
+    calls = {}
+
+    def _fake_forced(*, model, schema_model, system_blocks, user_message):
+        calls["forced"] = True
+        return _Result()
+
+    def _fail_agent(*a, **k):  # the strands Agent path must NOT be used on Bedrock
+        raise AssertionError("Bedrock should use forced_tool_fill, not Agent")
+
+    monkeypatch.setattr(direct_dsl_module, "forced_tool_fill", _fake_forced)
+    monkeypatch.setattr(direct_dsl_module, "Agent", _fail_agent)
+
+    dsl = DirectDslStrategy().generate(_Request(_BedrockLikeModel()))
+
+    assert calls.get("forced") is True
+    assert dsl == {"query": {"term": {"color": "red"}}}
+
+
+def test_ollama_falls_back_to_structured_output(monkeypatch):
+    """The core review concern: a non-Bedrock model must not crash into fallback."""
+    calls = {}
+
+    def _fail_forced(**k):
+        raise AssertionError("Ollama should not use the Bedrock forced-tool path")
+
+    class _FakeAgent:
+        def __init__(self, *a, **k):
+            calls["agent_built"] = True
+
+        def __call__(self, user_msg, structured_output_model):
+            calls["structured_output"] = True
+            return type("R", (), {"structured_output": _Result()})()
+
+    monkeypatch.setattr(direct_dsl_module, "forced_tool_fill", _fail_forced)
+    monkeypatch.setattr(direct_dsl_module, "Agent", _FakeAgent)
+
+    dsl = DirectDslStrategy().generate(_Request(_OllamaLikeModel()))
+
+    assert calls.get("structured_output") is True
+    assert dsl == {"query": {"term": {"color": "red"}}}

--- a/tests/unit/test_invoke_endpoint.py
+++ b/tests/unit/test_invoke_endpoint.py
@@ -45,6 +45,7 @@ class TestInvokeEndpoint:
             agent_name=None,
             headers=None,
             timeout=600,
+            context=None,
         )
 
     def test_messages_list_returns_success(self, client, mock_orchestrator):
@@ -67,6 +68,7 @@ class TestInvokeEndpoint:
             agent_name=None,
             headers=None,
             timeout=600,
+            context=None,
         )
 
     def test_explicit_agent_name(self, client, mock_orchestrator):
@@ -81,6 +83,7 @@ class TestInvokeEndpoint:
             agent_name="decomposer",
             headers=None,
             timeout=600,
+            context=None,
         )
 
     def test_missing_query_and_messages_returns_400(self, client, mock_orchestrator):
@@ -137,6 +140,7 @@ class TestInvokeEndpoint:
             agent_name=None,
             headers={"authorization": "Bearer test-token-123"},
             timeout=600,
+            context=None,
         )
 
     def test_empty_agent_response(self, client, mock_orchestrator):
@@ -175,6 +179,7 @@ class TestInvokeEndpoint:
             agent_name=None,
             headers=None,
             timeout=300,
+            context=None,
         )
 
     def test_default_timeout_is_600(self, client, mock_orchestrator):
@@ -187,4 +192,60 @@ class TestInvokeEndpoint:
             agent_name=None,
             headers=None,
             timeout=600,
+            context=None,
         )
+
+    def test_context_forwarded_to_orchestrator(self, client, mock_orchestrator):
+        """The structured `context` object is passed through to the orchestrator."""
+        context = {"index_name": "products", "template_id": "product_search"}
+        response = client.post(
+            "/invoke",
+            json={"query": "red shoes", "agent": "agentic_search", "context": context},
+        )
+
+        assert response.status_code == 200
+        mock_orchestrator.invoke.assert_called_once_with(
+            prompt="red shoes",
+            agent_name="agentic_search",
+            headers=None,
+            timeout=600,
+            context=context,
+        )
+
+    def test_response_format_inference_results_wraps_reply(
+        self, client, mock_orchestrator
+    ):
+        """response_format=inference_results wraps the reply in the ml-commons envelope."""
+        dsl = '{"query":{"match_all":{}}}'
+        mock_orchestrator.invoke = AsyncMock(return_value=dsl)
+
+        response = client.post(
+            "/invoke",
+            json={
+                "query": "everything",
+                "agent": "agentic_search",
+                "context": {"index_name": "idx"},
+                "response_format": "inference_results",
+            },
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        # Enveloped shape, not {response, status}: the DSL is a string at
+        # output[0].result so a connector's passthrough can read it.
+        assert "response" not in body
+        result = body["inference_results"][0]["output"][0]["result"]
+        assert result == dsl
+        assert isinstance(result, str)
+
+    def test_default_response_format_unchanged(self, client, mock_orchestrator):
+        """Without response_format, the default {response, status} shape is returned."""
+        response = client.post(
+            "/invoke", json={"query": "hi", "response_format": "text"}
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "success"
+        assert body["response"] == "This is the agent response."
+        assert "inference_results" not in body

--- a/tests/unit/test_response_formats.py
+++ b/tests/unit/test_response_formats.py
@@ -1,0 +1,28 @@
+"""Unit tests for the /invoke response envelopes."""
+
+from __future__ import annotations
+
+import pytest
+
+from server.response_formats import wrap_inference_results
+
+pytestmark = pytest.mark.unit
+
+
+def test_wrap_puts_result_string_at_output_result():
+    dsl = '{"query":{"match_all":{}}}'
+    env = wrap_inference_results(dsl)
+
+    output = env["inference_results"][0]["output"][0]
+    # Must be a STRING at output[0].result (what the connector passthrough reads).
+    assert output["result"] == dsl
+    assert isinstance(output["result"], str)
+    assert output["name"] == "response"
+    assert env["inference_results"][0]["status_code"] == 200
+
+
+def test_wrap_is_verbatim_not_reparsed():
+    # The envelope carries the reply as-is; it does not parse or reshape it.
+    assert wrap_inference_results("anything")["inference_results"][0]["output"][0][
+        "result"
+    ] == "anything"


### PR DESCRIPTION
 ### Description

  Adds a synchronous, non-streaming path that translates a natural-language query into an OpenSearch `_search` body on the agent server, and extends `/invoke` with the two request fields that path needs.

  **DSL generation.** A new generator (`BedrockDslGenerator`) is registered as an agent and invoked through `POST /invoke`. Given a natural-language query and a target index, it:
  - fetches the index mapping (using the caller's forwarded bearer token to reach the cluster),
  - prompts the model for a `_search` body via a single structured tool call (`structured_output_model`), and
  - returns the DSL as a JSON string, degrading to a `match_all` body on any failure (missing generator, generation error, or output that isn't a JSON object) so the caller gets a safe result instead of an error.

  The model provider is resolved through the existing model factory (Bedrock by default, Ollama supported).

  **Prompt caching.** The large, static system prompt (DSL rules + examples) is sent as Bedrock content blocks with a trailing cache point (`{"cachePoint": {"type": "default"}}`), so on warm calls it is served
  from cache and only the per-request tail (index mapping + question, in the user message) is billed. The request uses `structured_output_model` rather than the deprecated `structured_output()` specifically
  because the latter flattens the system prompt to a string and drops the cache point. The cache point is Bedrock-only and is harmlessly ignored on other providers.

  **`/invoke` request fields** (both optional; omitting either preserves current behavior):
  - **`context`** — an object passed through to the invoked agent as structured input; DSL generation reads `index_name` from it. Agents that don't use it ignore it.
  - **`response_format`** — when set to `"inference_results"`, the agent's string result is returned inside an `inference_results` envelope (`{"inference_results":[{"output":[{"name":...,"result":...}]}]}`)
  instead of the default `{"response": ..., "status": ...}` body.

  Example:
  ```json
  POST /invoke
  {
    "query": "5 cheapest red Nike shoes under $100",
    "agent": "dsl_generator",
    "context": { "index_name": "products" },
    "response_format": "inference_results"
  }
```

  Changes
  - dsl_generator.py (new): the generation engine — mapping fetch, cached system prompt, forced structured tool call, match_all fallback.
  - dsl_agent.py (new): registers the generator as an agent and adapts it to the /invoke calling convention; includes the inference_results envelope helper.
  - agent_orchestrator.py: invoke() accepts an optional context, forwarded (with the request's bearer token) to agents that opt in; other agents are called unchanged.
  - ag_ui_app.py: /invoke reads context and response_format; registers the DSL generator at startup.
  - types.py: adds InferenceResultsResponse for the enveloped response shape.
  - pyproject.toml: adds boto3.
  - examples/agentic-search/ + README: connector and FLOW-agent blueprints that wire an ml-commons cluster to /invoke.

  Backward compatibility: context and response_format default to today's behavior, so existing /invoke and /runs callers are unaffected.

  Testing
  - Unit (test_dsl_generator.py, test_dsl_agent.py, test_invoke_endpoint.py): the generator, the agent guard/fallback paths, context passthrough, and response_format enveloping.
  - End-to-end on a local OpenSearch cluster: a _search carrying an agentic clause resolved through a search pipeline into /invoke and returned the expected results; the generated DSL executed correctly against
  the cluster.

  ### Issues Resolved

  Resolves #140

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).