### PR TITLE
Add search-template fill generation strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Support non-streaming `/invoke` endpoint
 - `agentic_search` agent (natural-language query -> OpenSearch DSL) reachable via `POST /invoke`, with a per-request generation strategy (`context.strategy`, default `direct_dsl`) and example ml-commons connector/FLOW-agent wiring
 - `/invoke` `context` (structured input forwarded to the agent) and `response_format` (opt-in ml-commons `inference_results` envelope) request fields
+- `template_fill` generation strategy for `agentic_search`: fills a registered search template's Mustache parameters and renders them via `_render/template`, selected by passing `context.template_id`
 
 ### Fixed
 - Default agent now respects `BEDROCK_INFERENCE_PROFILE_ARN` env var instead of silently falling back to a hardcoded Sonnet 4 model (fixes #94)

--- a/examples/agentic-search/README.md
+++ b/examples/agentic-search/README.md
@@ -86,6 +86,66 @@ curl -s -XPOST http://localhost:9200/_plugins/_ml/agents/<agent_id>/_execute \
 The `_execute` response carries the generated DSL in its `result` field,
 confirming the connector → passthrough → `ModelTensor.result` chain.
 
+## Template mode (search-template fill)
+
+Template mode makes the LLM *fill* a registered search template's parameters
+instead of authoring free-form DSL; OpenSearch renders the values into the stored
+Mustache body via `_render/template`. The agent switches modes on the presence of
+`template_id` in the `/invoke` context bag: present → template fill, absent → the
+free-DSL path above. It is opt-in and additive — the connector above is unchanged
+and unaffected.
+
+Prerequisites, in order (all against the cluster):
+
+1. The target index exists, and the Mustache body is stored as a search template:
+   `PUT /_scripts/<template_name>` (author optional clauses as Mustache sections so
+   the model can omit params).
+2. The template is registered for filling, which derives and stores its
+   param-schema in `.plugins-ml-agentic-search-templates`:
+
+```bash
+curl -s -XPOST http://localhost:9200/_plugins/_ml/agentic_search_templates \
+  -H 'Content-Type: application/json' -d '{
+  "template_name": "product_search",
+  "index": "products",
+  "description": "Product search with filters and sort"
+}'
+#    -> {"template_id":"product_search","status":"created"}
+```
+
+Then register a **template-mode connector**: identical to step 1 above except
+`template_id` is baked into the connector's static parameters and interpolated
+into the context bag (one agent = one template; a selection layer in front is
+future work):
+
+```bash
+curl -s -XPOST http://localhost:9200/_plugins/_ml/connectors/_create \
+  -H 'Content-Type: application/json' -d '{
+  "name": "Agentic Search Template-Fill Connector",
+  "description": "Calls /invoke in template mode (fills a registered search template).",
+  "version": "1",
+  "protocol": "http",
+  "parameters": { "endpoint": "127.0.0.1:8001", "template_id": "product_search" },
+  "credential": { "token": "replace-with-agent-server-token" },
+  "actions": [{
+    "action_type": "predict",
+    "method": "POST",
+    "url": "http://${parameters.endpoint}/invoke",
+    "headers": {
+      "Content-Type": "application/json",
+      "Authorization": "Bearer ${credential.token}"
+    },
+    "request_body": "{ \"query\": \"${parameters.question}\", \"agent\": \"agentic_search\", \"context\": { \"index_name\": \"${parameters.index_name}\", \"template_id\": \"${parameters.template_id}\" }, \"response_format\": \"inference_results\" }",
+    "post_process_function": "connector.post_process.mlcommons.passthrough"
+  }]
+}'
+```
+
+The FLOW agent registration (step 2 above) and execution (step 3) are unchanged —
+only the `connector_id` differs. On the agent server, a fill that cannot produce
+valid DSL (unregistered template, failed render) degrades to the free-DSL path
+automatically, so a misconfigured `template_id` yields results rather than errors.
+
 ## Notes
 
 - If the cluster's trusted-endpoints regex blocks the host, add it via
@@ -94,3 +154,7 @@ confirming the connector → passthrough → `ModelTensor.result` chain.
 - If the agent server is on a private IP (e.g. `localhost` or an in-VPC host),
   ml-commons rejects the connector with "host name has private ip address" unless
   `plugins.ml_commons.connector.private_ip_enabled` is `true`.
+- Template mode reads the param-schema from the `.plugins-ml-agentic-search-templates`
+  system index. With the security plugin enabled, system-index protection blocks
+  direct reads unless the agent server's principal has system-index permission for
+  that pattern; on a security-disabled dev cluster it just works.

--- a/src/agents/agentic_search/agent.py
+++ b/src/agents/agentic_search/agent.py
@@ -71,13 +71,15 @@ class AgenticSearchAgent:
         if not index_name:
             raise ValueError("context.index_name is required")
 
-        strategy_name = context.get("strategy", DEFAULT_STRATEGY)
-        strategy: GenerationStrategy | None = STRATEGIES.get(strategy_name)
-        if strategy is None:
-            raise ValueError(f"unknown strategy '{strategy_name}'")
+        strategy = self._select_strategy(context)
 
         client = self._client(auth_token)
-        mapping = json.dumps(client.indices.get_mapping(index=index_name))
+        # Skip the per-query mapping fetch when the strategy doesn't need it
+        # (template fill fills typed params and uses no mapping). Strategies that
+        # omit `needs_mapping` are treated as needing it, so existing behavior holds.
+        mapping = ""
+        if getattr(strategy, "needs_mapping", True):
+            mapping = json.dumps(client.indices.get_mapping(index=index_name))
         dsl = strategy.generate(
             GenerationRequest(
                 question=prompt,
@@ -95,6 +97,23 @@ class AgenticSearchAgent:
         if not isinstance(dsl, dict):
             raise ValueError("strategy did not return a _search body object")
         return dsl
+
+    @staticmethod
+    def _select_strategy(context: dict[str, Any]) -> GenerationStrategy:
+        """Pick the generation strategy for this request.
+
+        An explicit ``context.strategy`` always wins. Otherwise the presence of
+        ``template_id`` is the mode switch: present -> ``template_fill``; absent ->
+        the free-DSL default. Template mode is opt-in and additive — callers that
+        send no ``template_id`` are unaffected.
+        """
+        strategy_name = context.get("strategy")
+        if strategy_name is None:
+            strategy_name = "template_fill" if context.get("template_id") else DEFAULT_STRATEGY
+        strategy: GenerationStrategy | None = STRATEGIES.get(strategy_name)
+        if strategy is None:
+            raise ValueError(f"unknown strategy '{strategy_name}'")
+        return strategy
 
     def _client(self, auth_token: str | None) -> OpenSearch:
         # Forward the caller's bearer token per request when present; otherwise

--- a/src/agents/agentic_search/prompts/__init__.py
+++ b/src/agents/agentic_search/prompts/__init__.py
@@ -2,6 +2,8 @@
 
 - :mod:`.direct_dsl` — rules, examples, ``EmitSearch`` schema, and cached system
   blocks for free-DSL generation (the default strategy).
+- :mod:`.template_fill` — the small prompt and ``FillTemplate`` tool name for
+  search-template fill.
 
 Strategies import their own prompt set from the submodule directly. Only
 ``FALLBACK_DSL`` is re-exported here, since the agent shell returns it on any

--- a/src/agents/agentic_search/prompts/template_fill.py
+++ b/src/agents/agentic_search/prompts/template_fill.py
@@ -1,0 +1,55 @@
+"""Prompt and cached system blocks for search-template fill (design part 2).
+
+Template fill hands the model a per-template ``FillTemplate`` tool whose fields
+ARE the template's Mustache parameters (1:1); the model returns only values
+(~5-30 tokens) and OpenSearch renders them into the stored body. The prompt is
+deliberately tiny — no DSL rules, no examples, no mapping — because the win here
+is output tokens, not caching (§7), and the typed tool schema (per-field
+descriptions + enum options) already carries the guidance the model needs.
+"""
+
+from __future__ import annotations
+
+from strands.types.content import SystemContentBlock
+
+FILL_MODEL_NAME = "FillTemplate"
+
+FILL_SYSTEM_PROMPT = (
+    "You extract search parameters from a user's question to fill a predefined "
+    "OpenSearch search template.\n"
+    "Call the FillTemplate tool exactly once. Fill only the parameters the "
+    "question clearly implies; leave everything else unset — do not guess.\n"
+    "Put ONLY content/topic words in any free-text query parameter — never counts, "
+    "filters, sort terms, or field names.\n"
+    "For enum parameters, choose only from the options that parameter allows.\n"
+    "If the question needs something these parameters cannot express — a field not "
+    "listed here, prefix/wildcard/fuzzy matching, aggregations, an unsupported range, "
+    "or custom scoring — set cannot_express=true and leave the other parameters unset. "
+    "Do not force an approximate fill; abstaining routes the question to a more capable "
+    "path."
+)
+
+def build_fill_system_blocks(system_prompt: str) -> list[SystemContentBlock]:
+    """Wrap a system-prompt string in the standard content blocks + cache point.
+
+    Factored out so a prompt-sweep experiment can build blocks from an alternate
+    prompt string; the module default :data:`FILL_SYSTEM_BLOCKS` is this applied to
+    :data:`FILL_SYSTEM_PROMPT`.
+    """
+    return [
+        {"text": system_prompt},
+        {"cachePoint": {"type": "default"}},
+    ]
+
+
+# Sent as content blocks with a trailing cache point, mirroring the direct-DSL
+# SYSTEM_BLOCKS. The fill prompt is small, so caching is a minor lever here (a short
+# prefix on a fast model may fall under the per-checkpoint token floor); the point
+# is harmless and keeps the two paths symmetric.
+FILL_SYSTEM_BLOCKS: list[SystemContentBlock] = build_fill_system_blocks(FILL_SYSTEM_PROMPT)
+
+FILL_USER_PROMPT = """\
+Question: {question}
+
+Fill the FillTemplate tool's parameters for this question.
+"""

--- a/src/agents/agentic_search/strategies/__init__.py
+++ b/src/agents/agentic_search/strategies/__init__.py
@@ -9,8 +9,15 @@ fill — write its module and register it in ``STRATEGIES``; nothing else change
 from __future__ import annotations
 
 from agents.agentic_search.strategies.direct_dsl import DirectDslStrategy
+from agents.agentic_search.strategies.template_fill import TemplateFillStrategy
 
 # Registry keyed by strategy name. `direct_dsl` is the default when a request
-# omits `context.strategy`.
-STRATEGIES = {DirectDslStrategy.name: DirectDslStrategy()}
+# omits `context.strategy`. `template_fill` fills a search template's params
+# instead of authoring DSL; the agent auto-selects it when a request carries a
+# `template_id` (see AgenticSearchAgent._select_strategy), and it falls back to
+# `direct_dsl`.
+STRATEGIES = {
+    DirectDslStrategy.name: DirectDslStrategy(),
+    TemplateFillStrategy.name: TemplateFillStrategy(),
+}
 DEFAULT_STRATEGY = DirectDslStrategy.name

--- a/src/agents/agentic_search/strategies/base.py
+++ b/src/agents/agentic_search/strategies/base.py
@@ -40,4 +40,11 @@ class GenerationStrategy(Protocol):
 
     name: str
 
+    # Whether the agent should fetch the index mapping onto the request before
+    # dispatching. Free-DSL strategies need it; template fill does not (it fills
+    # typed params, no mapping), so it declares ``False`` to skip the per-query
+    # fetch. Absent on a strategy => treated as ``True``, so existing strategies
+    # are unaffected.
+    needs_mapping: bool
+
     def generate(self, request: GenerationRequest) -> dict[str, Any]: ...

--- a/src/agents/agentic_search/strategies/template_fill.py
+++ b/src/agents/agentic_search/strategies/template_fill.py
@@ -1,0 +1,183 @@
+"""Search-template fill: the model fills a template's params, OpenSearch renders.
+
+This is design part 2, layered on the free-DSL port (G0). In template mode the LLM
+does one thing — fill *this template's* Mustache parameters — and OpenSearch's own
+engine renders them into the stored body. The model never authors DSL, so it emits
+~5-30 tokens (values only) instead of ~300 (a decode-latency win, G1), and the
+output is structurally valid by construction because the template owns the query
+shape (G3).
+
+Steps (§4.7):
+  1. Resolve the per-template ``FillTemplate`` model from the cached param-schema.
+  2. One forced tool call fills it (reusing the port's forced-toolChoice mechanism).
+  3. Drop unset params, hand the values to ``POST _render/template``, and unwrap the
+     rendered ``_search`` body.
+
+Reliability (§6): a single fallback. If anything above fails — unregistered
+template, a fill that won't validate, a body that won't render to legal DSL — we
+degrade to the ported free-DSL generator rather than return a wrong or empty
+result. Free-DSL is the proven path and carries its own ``match_all`` fail-safe, so
+we don't re-implement one here. Escaping is delegated to OpenSearch's renderer (the
+whole point of choosing ``_render/template`` in D4), not reimplemented in Python.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import replace
+from typing import Any
+
+from agents.agentic_search.prompts.template_fill import (
+    FILL_SYSTEM_BLOCKS,
+    FILL_USER_PROMPT,
+)
+from agents.agentic_search.strategies.base import GenerationRequest, GenerationStrategy
+from agents.agentic_search.strategies.direct_dsl import DirectDslStrategy
+from agents.agentic_search.strategies.forced_tool import forced_tool_fill
+from agents.agentic_search.template_schema import (
+    CANNOT_EXPRESS_FIELD,
+    TemplateSchemaCache,
+)
+
+logger = logging.getLogger(__name__)
+
+TEMPLATE_ID_KEY = "template_id"
+
+
+class _TemplateCannotExpress(Exception):
+    """The model abstained: the question needs a capability this template lacks.
+
+    Raised on the happy path so :meth:`TemplateFillStrategy.generate` routes to the
+    free-DSL fallback — the same handling as a structural failure, but triggered by the
+    model's own judgment rather than a broken render (§6).
+    """
+
+
+class TemplateFillStrategy:
+    """Fill a search template's params and render it into a ``_search`` body.
+
+    On any failure the request degrades to ``fallback`` (the ported free-DSL
+    generator). ``needs_mapping = False`` tells the agent to skip the per-query
+    mapping fetch on the happy path (fill doesn't use the mapping); the fallback
+    branch fetches it lazily only when it's actually needed.
+    """
+
+    name = "template_fill"
+    # The fill prompt carries no index mapping (the win is output tokens, §7), so the
+    # agent can skip the mapping fetch upfront; the fallback re-adds it on demand.
+    needs_mapping = False
+
+    def __init__(
+        self,
+        *,
+        fallback: GenerationStrategy | None = None,
+        schema_cache: TemplateSchemaCache | None = None,
+    ) -> None:
+        # Free-DSL fallback (G0). Defaults to the standard direct-DSL generator; a
+        # benchmark harness may inject a forced variant instead.
+        self._fallback = fallback if fallback is not None else DirectDslStrategy()
+        self._schema_cache = schema_cache if schema_cache is not None else TemplateSchemaCache()
+
+    def generate(self, request: GenerationRequest) -> dict[str, Any]:
+        template_id = request.context.get(TEMPLATE_ID_KEY)
+        if not template_id:
+            # template_fill was selected without a template_id — nothing to fill.
+            # Degrade rather than raise so the request still returns results.
+            logger.warning("template_fill selected but no template_id in context; falling back")
+            return self._fallback_generate(request)
+
+        try:
+            return self._fill_and_render(request, template_id)
+        except _TemplateCannotExpress:
+            # Not a failure: the model judged the question outside the template's
+            # expressive range and asked for the free-DSL path. Expected and healthy.
+            logger.info(
+                "Template %s cannot express the question; routing to free-DSL",
+                template_id,
+            )
+            return self._fallback_generate(request)
+        except Exception as e:  # noqa: BLE001 - any fill/render failure degrades to free-DSL
+            logger.warning(
+                "Template fill failed for template_id=%s (%s); falling back to free-DSL",
+                template_id,
+                e,
+            )
+            return self._fallback_generate(request)
+
+    def _fill_and_render(self, request: GenerationRequest, template_id: str) -> dict[str, Any]:
+        """The happy path: fill the template's params and render them into DSL.
+
+        Raises on any failure so :meth:`generate` can degrade to the fallback.
+        """
+        schema = self._schema_cache.get(template_id, request.client)
+
+        filled = forced_tool_fill(
+            model=request.model,
+            schema_model=schema.fill_model,
+            system_blocks=FILL_SYSTEM_BLOCKS,
+            user_message=FILL_USER_PROMPT.format(question=request.question),
+        )
+        # Only the params the model filled: dropping unset optionals lets the body's
+        # inverted-section defaults ({{^size}}10{{/size}}) and optional clauses
+        # ({{#color}}...{{/color}}) work, where a null would render an empty slot and
+        # break the JSON. ``by_alias`` recovers the real names from sanitized fields.
+        params = filled.model_dump(by_alias=True, exclude_none=True)
+
+        # Escape hatch: the synthetic abstain field (never a real Mustache param) lets
+        # the model decline a question this template can't express, instead of forcing a
+        # fill that renders valid-but-wrong DSL. Strip it either way — it must not reach
+        # the renderer — and route an abstention to the free-DSL fallback (§6).
+        abstained = bool(params.pop(CANNOT_EXPRESS_FIELD, False))
+        if abstained:
+            raise _TemplateCannotExpress(template_id)
+
+        rendered = self._render(request.client, template_id, params)
+        logger.info(
+            "Template fill for template_id=%s rendered %d params",
+            template_id,
+            len(params),
+        )
+        return rendered
+
+    @staticmethod
+    def _render(client: Any, template_id: str, params: dict[str, Any]) -> dict[str, Any]:
+        """Render the stored body via ``POST _render/template`` and unwrap the DSL.
+
+        OpenSearch's own Mustache engine renders (and safety-checks) the query, so
+        JSON-escaping and dialect are the cluster's concern, not ours (D4). The
+        rendered ``_search`` body comes back under ``template_output``.
+
+        Raises:
+            ValueError: The response has no ``template_output`` or it isn't a
+                ``_search`` body object.
+        """
+        resp = client.render_search_template(id=template_id, body={"params": params})
+        output = resp.get("template_output") if isinstance(resp, dict) else None
+        if output is None:
+            raise ValueError("_render/template returned no template_output")
+        # Most opensearch-py versions parse template_output into a dict; tolerate a
+        # string form by parsing it (still using the cluster's rendered bytes).
+        if isinstance(output, str):
+            output = json.loads(output)
+        if not isinstance(output, dict):
+            raise ValueError("rendered template_output is not a _search body object")
+        return output
+
+    def _fallback_generate(self, request: GenerationRequest) -> dict[str, Any]:
+        """Run the free-DSL fallback, re-adding the mapping the happy path skipped.
+
+        Because ``needs_mapping = False`` the agent didn't fetch the mapping, but the
+        free-DSL generator needs it — so fetch it here (only on the fallback path)
+        and hand the fallback a request that carries it.
+        """
+        req = request
+        if not request.mapping:
+            try:
+                mapping = json.dumps(request.client.indices.get_mapping(index=request.index_name))
+                req = replace(request, mapping=mapping)
+            except Exception as e:  # noqa: BLE001 - let the fallback try with what it has
+                logger.warning(
+                    "Fallback mapping fetch failed for index=%s (%s)", request.index_name, e
+                )
+        return self._fallback.generate(req)

--- a/src/agents/agentic_search/template_schema.py
+++ b/src/agents/agentic_search/template_schema.py
@@ -1,0 +1,290 @@
+"""Param-schema fetch + dynamic ``FillTemplate`` model, with a short TTL cache.
+
+Template fill needs a Pydantic model whose fields are *this template's* Mustache
+parameters (1:1), so the model can be forced as a tool and its output validated.
+That model can't be static — it differs per template — so it is built at query
+time from the template's **param-schema**, a metadata doc ml-commons derives at
+registration (from the Mustache body's parse tree + the index mapping) and stores
+one-per-template in the ``.plugins-ml-agentic-search-templates`` system index.
+
+This module owns two things:
+  1. :func:`build_fill_model` — turn a param-schema dict into a typed Pydantic
+     model (enums → ``Literal``, required → no default, optional → ``| None``).
+  2. :class:`TemplateSchemaCache` — read the schema doc for a ``template_id`` and
+     cache the built model in memory with a short TTL, so a schema edit takes at
+     most one TTL to take effect and a hot template is a one-entry lookup. Never
+     persisted.
+
+The schema is read per request the way mappings are read today; the agent server
+stays a stateless control plane that owns no template state of its own.
+"""
+
+from __future__ import annotations
+
+import keyword
+import logging
+import re
+import time
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from pydantic import ConfigDict, Field
+from pydantic import create_model as build_pydantic_model
+
+from agents.agentic_search.prompts.template_fill import FILL_MODEL_NAME
+
+logger = logging.getLogger(__name__)
+
+# ml-commons system index holding one param-schema doc per template, keyed by
+# ``template_id`` (also the core ``_scripts`` template name). Must match the ml-commons
+# CommonValue.ML_AGENTIC_SEARCH_TEMPLATES_INDEX constant.
+AGENTIC_SEARCH_TEMPLATES_INDEX = ".plugins-ml-agentic-search-templates"
+
+# How long a built model is trusted before the next query re-reads the schema doc.
+DEFAULT_SCHEMA_TTL_SECONDS = 60.0
+
+# Synthetic abstain field on every ``FillTemplate`` model (not a real Mustache param):
+# when the question needs a capability the template can't express, the model sets this
+# instead of force-filling params into valid-but-wrong DSL, and the strategy routes to
+# the free-DSL fallback. Optional, so it costs ~0 output tokens on the happy path.
+#
+# The enumerated triggers below are load-bearing: vaguer ("set true when unsure") and
+# heavier ("reason step by step first") wordings both over-abstained and lost accuracy
+# in a prompt sweep. Re-run the sweep before editing.
+CANNOT_EXPRESS_FIELD = "cannot_express"
+_CANNOT_EXPRESS_DESCRIPTION = (
+    "Set true when the question needs a capability NOT among these parameters. "
+    "Concretely set it true if the question: (a) restricts text matching to ONE "
+    "specific field (e.g. 'in the title', 'in the name') and no parameter isolates that "
+    "field; (b) demands an EXACT contiguous phrase / literal wording in a field and no "
+    "phrase parameter exists; (c) asks to RANK or BOOST by a signal (most popular, "
+    "trending, boost recent/newer, custom relevance) and no parameter or sort option "
+    "expresses that ranking; (d) asks for a COUNT-only answer, aggregation, faceting, or "
+    "grouping; (e) references a field, similarity ('products like X'), or predicate that "
+    "has no matching parameter. Otherwise leave it false and fill the parameters."
+)
+
+# param-schema "type" -> Python annotation for the non-enum case. ``number`` is
+# ``int | float``, int first, so ``size:5`` renders as ``5``; a bare ``float`` would
+# coerce it to ``5.0``, which OpenSearch rejects for integer fields.
+_SCALAR_TYPES: dict[str, Any] = {
+    "string": str,
+    "text": str,
+    "keyword": str,
+    "integer": int,
+    "int": int,
+    "long": int,
+    "number": int | float,
+    "float": float,
+    "double": float,
+    "boolean": bool,
+    "bool": bool,
+}
+
+
+@dataclass(frozen=True)
+class TemplateSchema:
+    """A template's param-schema and the Pydantic model built from it."""
+
+    template_id: str
+    index_binding: str | None
+    param_schema: dict[str, Any]
+    fill_model: type
+
+
+def _annotation_for(name: str, spec: dict[str, Any]) -> Any:
+    """Return the type annotation for one param, from its schema entry.
+
+    An ``enum`` becomes a ``Literal`` (an illegal value is then impossible); a bare
+    ``type`` maps to a Python scalar. Unknown types fall back to ``str`` — the model
+    can still emit a value and rendering stays the arbiter.
+    """
+    if "enum" in spec:
+        enum = spec["enum"]
+        if not isinstance(enum, list) or not enum:
+            raise ValueError(f"param '{name}' has an empty or non-list enum")
+        # Literal accepts a tuple of literal values (subscription form).
+        return Literal[tuple(enum)]
+    type_name = str(spec.get("type", "string")).lower()
+    py_type = _SCALAR_TYPES.get(type_name)
+    if py_type is None:
+        logger.warning(
+            "param '%s' has unknown type '%s'; treating as string", name, type_name
+        )
+        py_type = str
+    return py_type
+
+
+def _safe_field_name(param_name: str, used: set[str]) -> str:
+    """Return a valid, unique Python identifier for a param name.
+
+    A param name comes from a Mustache placeholder and can be anything the template
+    author wrote — dotted (``author.first_name``), leading-underscore, a Python
+    keyword, or a ``model_``/``model_config`` name that collides with Pydantic's
+    reserved namespace. Any of those would crash or shadow ``create_model``. We map
+    each to a safe field name and carry the real name as the field's ``alias`` so the
+    model still emits (and validates) the original key.
+    """
+    safe = re.sub(r"\W", "_", param_name)
+    # Field names may not start with a digit or underscore (underscore fields are
+    # treated as private by Pydantic and rejected by create_model).
+    if not safe or not (safe[0].isalpha()):
+        safe = "f_" + safe
+    if keyword.iskeyword(safe):
+        safe = safe + "_"
+    # Ensure uniqueness after collapsing (e.g. "a.b" and "a-b" both -> "a_b").
+    candidate = safe
+    n = 1
+    while candidate in used:
+        candidate = f"{safe}_{n}"
+        n += 1
+    used.add(candidate)
+    return candidate
+
+
+def build_fill_model(param_schema: dict[str, Any], *, model_name: str = FILL_MODEL_NAME) -> type:
+    """Build a Pydantic model whose fields are the template's params, 1:1.
+
+    Each param entry is ``{type, required?, enum?, description?}``. Required params
+    are non-nullable with no default (the model must supply them); optional params
+    are ``T | None`` defaulting to ``None`` so an omitted param simply disappears in
+    the Mustache body's optional sections.
+
+    Field names are sanitized to valid Python identifiers with the real param name
+    kept as the field ``alias`` (so an arbitrary Mustache name can't crash model
+    construction); callers must dump ``by_alias=True`` to recover the real names.
+    ``protected_namespaces=()`` disables Pydantic's ``model_*`` guard so a param like
+    ``model_id`` registers normally. ``extra="ignore"`` (not ``forbid``) so a single
+    hallucinated key doesn't fail the whole fill — an unknown key is simply dropped,
+    and the render-parse guard still backstops a bad result.
+
+    Raises:
+        ValueError: The schema is empty or a param entry is malformed.
+    """
+    if not param_schema:
+        raise ValueError("param_schema is empty; nothing to fill")
+
+    fields: dict[str, tuple[Any, Any]] = {}
+    used_names: set[str] = set()
+    # Reserve the abstain field's name so no real param can be sanitized onto it.
+    # A template whose author literally named a param ``cannot_express`` keeps that
+    # param (it maps to a distinct safe name) and simply forgoes the escape hatch.
+    add_abstain = CANNOT_EXPRESS_FIELD not in param_schema
+    if add_abstain:
+        used_names.add(CANNOT_EXPRESS_FIELD)
+    else:
+        logger.warning(
+            "template has a real param named '%s'; abstain escape hatch disabled",
+            CANNOT_EXPRESS_FIELD,
+        )
+    for name, spec in param_schema.items():
+        if not isinstance(spec, dict):
+            raise ValueError(f"param '{name}' schema entry must be an object")
+        annotation = _annotation_for(name, spec)
+        description = spec.get("description", "")
+        field_name = _safe_field_name(name, used_names)
+        if spec.get("required", False):
+            fields[field_name] = (annotation, Field(description=description, alias=name))
+        else:
+            # Optional: nullable + default None -> omitted from the tool's
+            # `required` and safely absent when the model doesn't fill it.
+            fields[field_name] = (
+                annotation | None,
+                Field(default=None, description=description, alias=name),
+            )
+
+    # Synthetic abstain field: optional bool, default False. Not a Mustache param, so
+    # the strategy strips it before rendering. Named identically to its alias (a plain
+    # identifier), so it survives ``model_dump(by_alias=True)`` for the strategy to read.
+    if add_abstain:
+        fields[CANNOT_EXPRESS_FIELD] = (
+            bool,
+            Field(default=False, description=_CANNOT_EXPRESS_DESCRIPTION),
+        )
+
+    model = build_pydantic_model(
+        model_name,
+        __config__=ConfigDict(
+            extra="ignore",
+            populate_by_name=True,
+            protected_namespaces=(),
+        ),
+        **fields,
+    )
+    return model
+
+
+class TemplateSchemaCache:
+    """Reads param-schema docs and caches the built models with a short TTL.
+
+    Keyed by ``template_id``. The cached value is the built model + schema, not any
+    client or credential, so it is safe to share across requests; the TTL bounds how
+    long a schema edit takes to take effect. A single-process, last-writer-wins dict
+    — adequate for a stateless control plane (each worker keeps its own).
+    """
+
+    def __init__(self, *, ttl_seconds: float = DEFAULT_SCHEMA_TTL_SECONDS) -> None:
+        self._ttl = ttl_seconds
+        self._cache: dict[str, tuple[TemplateSchema, float]] = {}
+
+    def get(self, template_id: str, client: Any) -> TemplateSchema:
+        """Return the ``TemplateSchema`` for ``template_id``, fetching if stale.
+
+        Uses ``client`` (the per-request, caller-authenticated OpenSearch client) to
+        read the schema doc when the cache misses or the entry has expired.
+
+        Raises:
+            ValueError: No schema doc for ``template_id`` (unregistered template),
+                or the doc has no usable ``param_schema``.
+        """
+        now = time.monotonic()
+        cached = self._cache.get(template_id)
+        if cached is not None and now < cached[1]:
+            return cached[0]
+
+        schema = self._fetch_and_build(template_id, client)
+        self._cache[template_id] = (schema, now + self._ttl)
+        return schema
+
+    def _fetch_and_build(self, template_id: str, client: Any) -> TemplateSchema:
+        doc = self._fetch_doc(template_id, client)
+        if doc is None:
+            raise ValueError(
+                f"no param-schema registered for template_id '{template_id}'"
+            )
+        param_schema = doc.get("param_schema")
+        if not isinstance(param_schema, dict) or not param_schema:
+            raise ValueError(
+                f"param-schema for template_id '{template_id}' is missing or empty"
+            )
+        fill_model = build_fill_model(param_schema)
+        logger.info(
+            "Built FillTemplate model for template_id=%s (%d params)",
+            template_id,
+            len(param_schema),
+        )
+        return TemplateSchema(
+            template_id=template_id,
+            index_binding=doc.get("index_binding"),
+            param_schema=param_schema,
+            fill_model=fill_model,
+        )
+
+    @staticmethod
+    def _fetch_doc(template_id: str, client: Any) -> dict[str, Any] | None:
+        """Fetch the schema doc from the system index. Returns None if absent.
+
+        The doc ``_id`` is the ``template_id``. Uses the typed ``get`` call; a
+        missing doc (404) surfaces as an exception from opensearch-py, which we
+        translate to ``None`` so the caller raises a clear "unregistered" error.
+        """
+        try:
+            resp = client.get(index=AGENTIC_SEARCH_TEMPLATES_INDEX, id=template_id)
+        except Exception as e:  # noqa: BLE001 - 404 / index-missing -> unregistered
+            logger.warning(
+                "Schema-doc fetch for template_id=%s failed: %s", template_id, e
+            )
+            return None
+        if not resp or not resp.get("found"):
+            return None
+        return resp.get("_source") or None

--- a/tests/unit/test_template_fill.py
+++ b/tests/unit/test_template_fill.py
@@ -1,0 +1,323 @@
+"""Unit tests for the template_fill generation strategy.
+
+The Bedrock fill and the OpenSearch client are stubbed, so nothing hits a cluster
+or an LLM. Covers: the happy path (fill -> _render/template -> unwrapped DSL), the
+mode switch + strategy selection in the agent, and every degrade-to-free-DSL
+fallback branch (no template_id, unregistered template, fill failure, render
+failure), including that the fallback re-fetches the mapping the happy path skips.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agents.agentic_search import agent as agent_module
+from agents.agentic_search.agent import AgenticSearchAgent
+from agents.agentic_search.strategies import template_fill as tf_module
+from agents.agentic_search.strategies.base import GenerationRequest
+from agents.agentic_search.strategies.template_fill import TemplateFillStrategy
+from agents.agentic_search.template_schema import TemplateSchema, build_fill_model
+
+pytestmark = pytest.mark.unit
+
+PRODUCT_SCHEMA = {
+    "lex_query": {"type": "string", "required": True},
+    "size": {"type": "integer", "required": False},
+    "color": {"type": "string", "required": False},
+    "price_max": {"type": "float", "required": False},
+}
+
+RENDERED_DSL = {
+    "size": 5,
+    "query": {"bool": {"must": [{"multi_match": {"query": "shoes", "fields": ["title"]}}]}},
+}
+
+
+class _StubSchemaCache:
+    """Returns a prebuilt TemplateSchema (or raises to simulate unregistered)."""
+
+    def __init__(self, *, schema=None, raises=None):
+        self._schema = schema
+        self._raises = raises
+        self.calls = []
+
+    def get(self, template_id, client):
+        self.calls.append(template_id)
+        if self._raises is not None:
+            raise self._raises
+        return self._schema
+
+
+class _StubFallback:
+    """Free-DSL fallback stub; records the request it was handed."""
+
+    name = "direct_dsl"
+    needs_mapping = True
+
+    def __init__(self, returns=None):
+        self._returns = returns if returns is not None else {"query": {"match_all": {}}}
+        self.calls = []
+
+    def generate(self, request):
+        self.calls.append(request)
+        return self._returns
+
+
+class _StubRenderClient:
+    """Stands in for the OpenSearch client's render_search_template + get_mapping."""
+
+    def __init__(self, *, template_output=RENDERED_DSL, render_exc=None, mapping=None):
+        self._template_output = template_output
+        self._render_exc = render_exc
+        self._mapping = mapping if mapping is not None else {"products": {"mappings": {}}}
+        self.render_calls = []
+        self.mapping_calls = []
+
+    def render_search_template(self, id, body):  # noqa: A002 - mirrors client sig
+        self.render_calls.append((id, body))
+        if self._render_exc is not None:
+            raise self._render_exc
+        return {"template_output": self._template_output}
+
+    class _Indices:
+        def __init__(self, outer):
+            self._outer = outer
+
+        def get_mapping(self, index):
+            self._outer.mapping_calls.append(index)
+            return self._outer._mapping
+
+    @property
+    def indices(self):
+        return _StubRenderClient._Indices(self)
+
+
+def _make_request(client, *, template_id="product_search", mapping="", model=None):
+    return GenerationRequest(
+        question="5 cheapest red shoes under $100",
+        index_name="products",
+        mapping=mapping,
+        context={"index_name": "products", "template_id": template_id} if template_id
+        else {"index_name": "products"},
+        model=model or object(),
+        client=client,
+    )
+
+
+def _product_schema_obj():
+    return TemplateSchema(
+        template_id="product_search",
+        index_binding="products",
+        param_schema=PRODUCT_SCHEMA,
+        fill_model=build_fill_model(PRODUCT_SCHEMA),
+    )
+
+
+# --- happy path -------------------------------------------------------------
+
+
+def test_happy_path_fills_renders_and_unwraps(monkeypatch):
+    client = _StubRenderClient()
+    cache = _StubSchemaCache(schema=_product_schema_obj())
+    strat = TemplateFillStrategy(schema_cache=cache)
+
+    # Stub the forced fill to return validated params (no Bedrock).
+    filled = _product_schema_obj().fill_model.model_validate(
+        {"lex_query": "shoes", "size": 5, "color": "red", "price_max": 100}
+    )
+    monkeypatch.setattr(tf_module, "forced_tool_fill", lambda **kw: filled)
+
+    out = strat.generate(_make_request(client))
+
+    assert out == RENDERED_DSL
+    # Rendered by template_id with only the filled (non-None) params.
+    assert client.render_calls == [
+        ("product_search", {"params": {"lex_query": "shoes", "size": 5, "color": "red", "price_max": 100.0}})
+    ]
+    assert cache.calls == ["product_search"]
+
+
+def test_cannot_express_routes_to_fallback(monkeypatch):
+    # The model sets the abstain field -> skip render, route to free-DSL. The abstain
+    # field must never reach the renderer.
+    fb = _StubFallback()
+    client = _StubRenderClient()
+    strat = TemplateFillStrategy(fallback=fb, schema_cache=_StubSchemaCache(schema=_product_schema_obj()))
+    filled = _product_schema_obj().fill_model.model_validate(
+        {"lex_query": "x", "cannot_express": True}
+    )
+    monkeypatch.setattr(tf_module, "forced_tool_fill", lambda **kw: filled)
+
+    out = strat.generate(_make_request(client, mapping='{"m":1}'))
+
+    assert out == {"query": {"match_all": {}}}  # the fallback's result
+    assert len(fb.calls) == 1
+    assert client.render_calls == []  # never rendered
+
+
+def test_cannot_express_false_renders_normally(monkeypatch):
+    # abstain=False is the happy path: the synthetic field is stripped, render proceeds.
+    client = _StubRenderClient()
+    strat = TemplateFillStrategy(schema_cache=_StubSchemaCache(schema=_product_schema_obj()))
+    filled = _product_schema_obj().fill_model.model_validate(
+        {"lex_query": "shoes", "cannot_express": False}
+    )
+    monkeypatch.setattr(tf_module, "forced_tool_fill", lambda **kw: filled)
+
+    out = strat.generate(_make_request(client))
+
+    assert out == RENDERED_DSL
+    # cannot_express is stripped before the params reach the renderer.
+    assert client.render_calls == [("product_search", {"params": {"lex_query": "shoes"}})]
+
+
+def test_render_output_string_is_parsed(monkeypatch):
+    # Some client versions return template_output as a JSON string.
+    client = _StubRenderClient(template_output=json.dumps(RENDERED_DSL))
+    strat = TemplateFillStrategy(schema_cache=_StubSchemaCache(schema=_product_schema_obj()))
+    filled = _product_schema_obj().fill_model.model_validate({"lex_query": "shoes"})
+    monkeypatch.setattr(tf_module, "forced_tool_fill", lambda **kw: filled)
+
+    out = strat.generate(_make_request(client))
+    assert out == RENDERED_DSL
+
+
+# --- fallback branches ------------------------------------------------------
+
+
+def test_no_template_id_falls_back():
+    fb = _StubFallback()
+    strat = TemplateFillStrategy(fallback=fb, schema_cache=_StubSchemaCache())
+    client = _StubRenderClient()
+    out = strat.generate(_make_request(client, template_id=None, mapping='{"m":1}'))
+    assert out == {"query": {"match_all": {}}}
+    assert len(fb.calls) == 1
+    assert client.render_calls == []  # never attempted a render
+
+
+def test_unregistered_template_falls_back():
+    fb = _StubFallback()
+    cache = _StubSchemaCache(raises=ValueError("no param-schema registered"))
+    strat = TemplateFillStrategy(fallback=fb, schema_cache=cache)
+    out = strat.generate(_make_request(_StubRenderClient(), mapping='{"m":1}'))
+    assert out == {"query": {"match_all": {}}}
+    assert len(fb.calls) == 1
+
+
+def test_fill_failure_falls_back(monkeypatch):
+    fb = _StubFallback()
+    strat = TemplateFillStrategy(fallback=fb, schema_cache=_StubSchemaCache(schema=_product_schema_obj()))
+
+    def _boom(**kw):
+        raise ValueError("forced tool input failed validation")
+
+    monkeypatch.setattr(tf_module, "forced_tool_fill", _boom)
+    out = strat.generate(_make_request(_StubRenderClient(), mapping='{"m":1}'))
+    assert out == {"query": {"match_all": {}}}
+    assert len(fb.calls) == 1
+
+
+def test_render_failure_falls_back(monkeypatch):
+    fb = _StubFallback()
+    client = _StubRenderClient(render_exc=RuntimeError("bad Mustache"))
+    strat = TemplateFillStrategy(fallback=fb, schema_cache=_StubSchemaCache(schema=_product_schema_obj()))
+    filled = _product_schema_obj().fill_model.model_validate({"lex_query": "shoes"})
+    monkeypatch.setattr(tf_module, "forced_tool_fill", lambda **kw: filled)
+
+    out = strat.generate(_make_request(client, mapping='{"m":1}'))
+    assert out == {"query": {"match_all": {}}}
+    assert len(fb.calls) == 1
+
+
+def test_missing_template_output_falls_back(monkeypatch):
+    fb = _StubFallback()
+    client = _StubRenderClient(template_output=None)  # -> render returns no output
+    # override render to return an empty dict (no template_output key)
+    client.render_search_template = lambda id, body: {}  # noqa: A002
+    strat = TemplateFillStrategy(fallback=fb, schema_cache=_StubSchemaCache(schema=_product_schema_obj()))
+    filled = _product_schema_obj().fill_model.model_validate({"lex_query": "shoes"})
+    monkeypatch.setattr(tf_module, "forced_tool_fill", lambda **kw: filled)
+
+    out = strat.generate(_make_request(client, mapping='{"m":1}'))
+    assert out == {"query": {"match_all": {}}}
+
+
+def test_fallback_refetches_mapping_when_absent():
+    # Happy path skips the mapping (needs_mapping=False), so the fallback must fetch
+    # it. The stub fallback records the request it received; assert it has a mapping.
+    fb = _StubFallback()
+    client = _StubRenderClient()
+    cache = _StubSchemaCache(raises=ValueError("unregistered"))
+    strat = TemplateFillStrategy(fallback=fb, schema_cache=cache)
+
+    strat.generate(_make_request(client, mapping=""))  # no mapping on the request
+
+    assert client.mapping_calls == ["products"]  # fallback fetched it
+    handed = fb.calls[0]
+    assert json.loads(handed.mapping) == {"products": {"mappings": {}}}
+
+
+# --- agent-level mode switch ------------------------------------------------
+
+
+class _AgentStubStrategy:
+    name = "template_fill"
+    needs_mapping = False
+
+    def __init__(self):
+        self.calls = []
+
+    def generate(self, request):
+        self.calls.append(request)
+        return {"query": {"term": {"color": "red"}}}
+
+
+def test_agent_auto_selects_template_fill_on_template_id(monkeypatch):
+    """template_id present -> the agent routes to template_fill and skips mapping."""
+    monkeypatch.setattr(agent_module, "create_model", lambda: object())
+    strat = _AgentStubStrategy()
+    monkeypatch.setattr(agent_module, "STRATEGIES", {"template_fill": strat, "direct_dsl": object()})
+    monkeypatch.setattr(agent_module, "DEFAULT_STRATEGY", "direct_dsl")
+
+    a = AgenticSearchAgent("http://localhost:9200")
+    client = _StubRenderClient()
+    monkeypatch.setattr(a, "_client", lambda auth_token: client)
+
+    out = a("red shoes", context={"index_name": "products", "template_id": "product_search"})
+
+    assert json.loads(out) == {"query": {"term": {"color": "red"}}}
+    assert len(strat.calls) == 1
+    # needs_mapping=False -> the agent did NOT fetch the mapping upfront.
+    assert client.mapping_calls == []
+    assert strat.calls[0].mapping == ""
+
+
+def test_agent_defaults_to_free_dsl_without_template_id(monkeypatch):
+    """No template_id -> the default (free-DSL) strategy, mapping fetched."""
+    monkeypatch.setattr(agent_module, "create_model", lambda: object())
+
+    class _Default:
+        name = "direct_dsl"
+        needs_mapping = True
+
+        def __init__(self):
+            self.calls = []
+
+        def generate(self, request):
+            self.calls.append(request)
+            return {"query": {"match_all": {}}}
+
+    default = _Default()
+    monkeypatch.setattr(agent_module, "STRATEGIES", {"direct_dsl": default})
+    monkeypatch.setattr(agent_module, "DEFAULT_STRATEGY", "direct_dsl")
+
+    a = AgenticSearchAgent("http://localhost:9200")
+    client = _StubRenderClient()
+    monkeypatch.setattr(a, "_client", lambda auth_token: client)
+
+    a("red shoes", context={"index_name": "products"})
+
+    assert len(default.calls) == 1
+    assert client.mapping_calls == ["products"]  # mapping fetched for free-DSL

--- a/tests/unit/test_template_schema.py
+++ b/tests/unit/test_template_schema.py
@@ -1,0 +1,237 @@
+"""Unit tests for the param-schema -> dynamic FillTemplate model + TTL cache.
+
+Covers building the Pydantic model from a param-schema (types, enums, required vs
+optional), the schema-doc fetch from the system index, and the TTL cache (hit,
+miss, expiry, unregistered/empty-schema errors). No cluster or LLM is touched.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agents.agentic_search import template_schema as ts_module
+from agents.agentic_search.template_schema import (
+    AGENTIC_SEARCH_TEMPLATES_INDEX,
+    CANNOT_EXPRESS_FIELD,
+    TemplateSchemaCache,
+    build_fill_model,
+)
+
+pytestmark = pytest.mark.unit
+
+# The worked-example schema from the design doc (§4.3).
+PRODUCT_SCHEMA = {
+    "lex_query": {"type": "string", "required": True, "description": "content words only"},
+    "size": {"type": "integer", "required": False},
+    "color": {"type": "string", "required": False},
+    "brand": {"type": "string", "required": False},
+    "price_max": {"type": "float", "required": False},
+    "sort_by": {"type": "string", "enum": ["price", "rating", "created_at"], "required": False},
+    "sort_order": {"type": "string", "enum": ["asc", "desc"], "required": False},
+}
+
+
+class _StubClient:
+    """Stands in for the OpenSearch client's ``get`` on the system index."""
+
+    def __init__(self, doc=None, *, raise_exc=None):
+        self._doc = doc
+        self._raise = raise_exc
+        self.get_calls = []
+
+    def get(self, index, id):  # noqa: A002 - mirrors opensearch-py signature
+        self.get_calls.append((index, id))
+        if self._raise is not None:
+            raise self._raise
+        if self._doc is None:
+            return {"found": False}
+        return {"found": True, "_source": self._doc}
+
+
+# --- build_fill_model -------------------------------------------------------
+
+
+def test_build_model_required_and_optional():
+    model = build_fill_model(PRODUCT_SCHEMA)
+    schema = model.model_json_schema()
+    # Only the required param is in `required`; optionals are nullable + default.
+    assert schema["required"] == ["lex_query"]
+    assert model.model_fields["size"].is_required() is False
+
+
+def test_build_model_enum_becomes_literal():
+    model = build_fill_model(PRODUCT_SCHEMA)
+    # A value outside the enum is rejected; a valid one passes.
+    with pytest.raises(Exception):
+        model.model_validate({"lex_query": "x", "sort_by": "bogus"})
+    inst = model.model_validate({"lex_query": "x", "sort_by": "price"})
+    assert inst.sort_by == "price"
+
+
+def test_build_model_ignores_extra_params():
+    model = build_fill_model(PRODUCT_SCHEMA)
+    # A hallucinated key is dropped (extra="ignore"), not rejected — one stray key
+    # must not fail the whole fill; the render-parse guard backstops a bad result.
+    inst = model.model_validate({"lex_query": "x", "not_a_param": 1})
+    assert "not_a_param" not in inst.model_dump(by_alias=True, exclude_none=True)
+
+
+def _params(inst, **dump_kwargs):
+    """Dump a fill instance minus the synthetic abstain field (as the strategy does)."""
+    dumped = inst.model_dump(by_alias=True, **dump_kwargs)
+    dumped.pop(CANNOT_EXPRESS_FIELD, None)
+    return dumped
+
+
+def test_build_model_number_preserves_int():
+    # A "number"-typed param filled with an integer must render as an int, not 5.0
+    # (OpenSearch rejects a float where an int is expected, e.g. size).
+    model = build_fill_model({"size": {"type": "number", "required": True}})
+    dumped = _params(model.model_validate({"size": 5}))
+    assert dumped == {"size": 5}
+    assert isinstance(dumped["size"], int)
+    # A decimal still stays a float.
+    assert _params(model.model_validate({"size": 5.5})) == {"size": 5.5}
+
+
+def test_build_model_coerces_and_types():
+    model = build_fill_model(PRODUCT_SCHEMA)
+    inst = model.model_validate({"lex_query": "shoes", "size": 5, "price_max": 100})
+    dumped = _params(inst, exclude_none=True)
+    # size is "integer" -> stays int; price_max is "float" -> 100.0.
+    assert dumped == {"lex_query": "shoes", "size": 5, "price_max": 100.0}
+
+
+def test_build_model_awkward_param_names():
+    # Dotted, model_-prefixed, leading-underscore, and keyword names must not crash
+    # create_model; the real name is preserved as the field alias.
+    schema = {
+        "author.first_name": {"type": "string", "required": True},
+        "model_id": {"type": "string", "required": False},
+        "_internal": {"type": "string", "required": False},
+        "class": {"type": "string", "required": False},
+    }
+    model = build_fill_model(schema)
+    inst = model.model_validate(
+        {"author.first_name": "John", "model_id": "m1", "_internal": "z", "class": "c"}
+    )
+    dumped = _params(inst, exclude_none=True)
+    assert dumped == {
+        "author.first_name": "John",
+        "model_id": "m1",
+        "_internal": "z",
+        "class": "c",
+    }
+
+
+def test_build_model_colliding_sanitized_names_stay_distinct():
+    # "a.b" and "a-b" both sanitize to "a_b"; both must still round-trip by alias.
+    schema = {
+        "a.b": {"type": "string", "required": True},
+        "a-b": {"type": "string", "required": True},
+    }
+    model = build_fill_model(schema)
+    dumped = _params(model.model_validate({"a.b": "x", "a-b": "y"}))
+    assert dumped == {"a.b": "x", "a-b": "y"}
+
+
+def test_build_model_empty_schema_raises():
+    with pytest.raises(ValueError, match="empty"):
+        build_fill_model({})
+
+
+def test_build_model_bad_enum_raises():
+    with pytest.raises(ValueError, match="enum"):
+        build_fill_model({"x": {"type": "string", "enum": []}})
+
+
+def test_build_model_unknown_type_falls_back_to_string():
+    model = build_fill_model({"weird": {"type": "geo_point", "required": True}})
+    inst = model.model_validate({"weird": "anything"})
+    assert inst.weird == "anything"
+
+
+# --- cannot_express escape hatch --------------------------------------------
+
+
+def test_build_model_adds_cannot_express_field():
+    # The synthetic abstain field is added to every model, optional, default False,
+    # and is not in `required` (so it costs nothing on the happy path).
+    model = build_fill_model(PRODUCT_SCHEMA)
+    assert CANNOT_EXPRESS_FIELD in model.model_fields
+    assert CANNOT_EXPRESS_FIELD not in model.model_json_schema()["required"]
+    inst = model.model_validate({"lex_query": "x"})
+    assert getattr(inst, CANNOT_EXPRESS_FIELD) is False
+
+
+def test_build_model_cannot_express_can_be_set():
+    model = build_fill_model(PRODUCT_SCHEMA)
+    inst = model.model_validate({"lex_query": "x", CANNOT_EXPRESS_FIELD: True})
+    assert getattr(inst, CANNOT_EXPRESS_FIELD) is True
+    # It round-trips by alias (plain identifier, so alias == field name).
+    assert inst.model_dump(by_alias=True)[CANNOT_EXPRESS_FIELD] is True
+
+
+def test_build_model_real_param_named_cannot_express_wins():
+    # A template that literally names a param `cannot_express` keeps its real param
+    # (the escape hatch is disabled for that template rather than shadowing the param).
+    schema = {CANNOT_EXPRESS_FIELD: {"type": "string", "required": True}}
+    model = build_fill_model(schema)
+    # The field is the real (string) param, not the synthetic bool.
+    inst = model.model_validate({CANNOT_EXPRESS_FIELD: "hello"})
+    assert getattr(inst, CANNOT_EXPRESS_FIELD) == "hello"
+
+
+# --- TemplateSchemaCache ----------------------------------------------------
+
+
+def test_cache_fetches_and_builds():
+    client = _StubClient(doc={"param_schema": PRODUCT_SCHEMA, "index_binding": "products"})
+    cache = TemplateSchemaCache()
+    schema = cache.get("product_search", client)
+    assert schema.template_id == "product_search"
+    assert schema.index_binding == "products"
+    assert client.get_calls == [(AGENTIC_SEARCH_TEMPLATES_INDEX, "product_search")]
+    # The built model validates a fill.
+    inst = schema.fill_model.model_validate({"lex_query": "shoes"})
+    assert inst.lex_query == "shoes"
+
+
+def test_cache_hit_avoids_second_fetch():
+    client = _StubClient(doc={"param_schema": PRODUCT_SCHEMA})
+    cache = TemplateSchemaCache(ttl_seconds=1000)
+    cache.get("product_search", client)
+    cache.get("product_search", client)
+    assert len(client.get_calls) == 1  # second call served from cache
+
+
+def test_cache_expiry_refetches(monkeypatch):
+    client = _StubClient(doc={"param_schema": PRODUCT_SCHEMA})
+    fake_now = {"t": 1000.0}
+    monkeypatch.setattr(ts_module.time, "monotonic", lambda: fake_now["t"])
+    cache = TemplateSchemaCache(ttl_seconds=60)
+    cache.get("product_search", client)
+    fake_now["t"] = 1000.0 + 61  # past the TTL
+    cache.get("product_search", client)
+    assert len(client.get_calls) == 2  # re-read after expiry
+
+
+def test_cache_unregistered_template_raises():
+    client = _StubClient(doc=None)  # {"found": False}
+    cache = TemplateSchemaCache()
+    with pytest.raises(ValueError, match="no param-schema registered"):
+        cache.get("missing", client)
+
+
+def test_cache_fetch_exception_treated_as_unregistered():
+    client = _StubClient(raise_exc=RuntimeError("index_not_found_exception"))
+    cache = TemplateSchemaCache()
+    with pytest.raises(ValueError, match="no param-schema registered"):
+        cache.get("missing", client)
+
+
+def test_cache_empty_param_schema_raises():
+    client = _StubClient(doc={"param_schema": {}})
+    cache = TemplateSchemaCache()
+    with pytest.raises(ValueError, match="missing or empty"):
+        cache.get("empty", client)


### PR DESCRIPTION
### Description

Adds a generation strategy that fills a registered OpenSearch search template's Mustache parameters instead of authoring DSL from scratch, then lets OpenSearch render the stored body via `POST _render/template`.

Because the template owns the query shape, the model emits only parameter values rather than a full query body, and the rendered result is structurally valid by construction. The strategy is selected when a request carries a `template_id` in its context; everything else is unchanged.

**How it works**

1. `template_schema.py` reads the template's param-schema from the ml-commons system index and builds a per-template Pydantic model (`enum` → `Literal`, required → no default), TTL-cached in memory.
2. `strategies/template_fill.py` fills that model with one forced tool call, drops unset optionals, and renders the parameters into a `_search` body.
3. A synthetic `cannot_express` field lets the model decline a question the template cannot express, rather than forcing a fill that renders valid-but-wrong DSL.
4. Any fill or render failure, and any abstention, degrades to the existing free-DSL strategy, which re-fetches the index mapping the fill path skips.

Depends on the ml-commons param-schema API (opensearch-project/ml-commons#4944), which supplies the schema document this reads.

### Related Issues

Related to #150

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
