### PR TITLE
Lint: Replace TypeVar with [T] and [R], deprecated imports and rule s…

### DIFF
--- a/run_server.py
+++ b/run_server.py
@@ -26,7 +26,7 @@ if sys.path[0] != _src_dir:
 # Load environment variables FIRST, before any server imports that read config.
 # ag_ui_app.py calls create_app() at module level, which creates ServerConfig()
 # from env vars. If load_dotenv() runs after that import, .env values are missed.
-from dotenv import load_dotenv
+from dotenv import load_dotenv  # noqa: E402
 
 load_dotenv()
 
@@ -58,9 +58,9 @@ from server.logging_config import configure_logging, get_logging_config  # noqa:
 use_json, log_level = get_logging_config()
 configure_logging(use_json=use_json, log_level=log_level, force=True)
 
-from utils.logging_helpers import get_logger, log_info_event  # noqa: E402
 from server.ag_ui_app import app  # noqa: E402
 from server.config import get_config  # noqa: E402
+from utils.logging_helpers import get_logger, log_info_event  # noqa: E402
 
 logger = get_logger(__name__)
 

--- a/run_server.py
+++ b/run_server.py
@@ -43,7 +43,11 @@ if get_provider() == "bedrock" and not os.getenv("AWS_ACCESS_KEY_ID"):
         _cp.read(_cred_file)
         _profile = os.getenv("AWS_PROFILE", "default")
         if _cp.has_section(_profile):
-            for key in ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"):
+            for key in (
+                "AWS_ACCESS_KEY_ID",
+                "AWS_SECRET_ACCESS_KEY",
+                "AWS_SESSION_TOKEN",
+            ):
                 val = _cp.get(_profile, key, fallback=None) or _cp.get(
                     _profile, key.lower(), fallback=None
                 )

--- a/src/agents/agentic_search/strategies/direct_dsl.py
+++ b/src/agents/agentic_search/strategies/direct_dsl.py
@@ -59,7 +59,9 @@ def _fetch_sample_document(client: Any, index_name: str) -> str:
         }
         return json.dumps(truncated)
     except Exception:  # noqa: BLE001 - best-effort; proceed without a sample
-        logger.warning("Sample document fetch failed for index=%s; proceeding without", index_name)
+        logger.warning(
+            "Sample document fetch failed for index=%s; proceeding without", index_name
+        )
         return ""
 
 

--- a/src/agents/agentic_search/strategies/forced_tool.py
+++ b/src/agents/agentic_search/strategies/forced_tool.py
@@ -67,7 +67,11 @@ def forced_tool_fill(
         ValueError: The forced tool produced no input, or the input failed
             validation against ``schema_model``.
     """
-    spec = tool_spec if tool_spec is not None else convert_pydantic_to_tool_spec(schema_model)
+    spec = (
+        tool_spec
+        if tool_spec is not None
+        else convert_pydantic_to_tool_spec(schema_model)
+    )
     tool_name = spec["name"]
 
     client = model.client  # botocore bedrock-runtime client (pooled connection)

--- a/src/agents/art/specialized_agents.py
+++ b/src/agents/art/specialized_agents.py
@@ -14,17 +14,19 @@ from strands.tools.mcp import MCPClient
 from utils.logging_helpers import get_logger, log_info_event
 from utils.model_factory import create_model
 from utils.monitored_tool import monitored_tool
+
 # Import experimentation tools. This agent is meant to do only sanity checks,
 # so we don't need all experiment tools.
 # We need to adjust the path here to make tools available,
 # otherwise not found.
 _src_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../../src")
-import sys
+import sys  # noqa: E402
+
 sys.path.insert(0, _src_dir)
-from tools.art.experiment_tools import (
+from tools.art.experiment_tools import (  # noqa: E402
     aggregate_experiment_results,
 )
-from tools.art.ubi_metrics_tools import compute_ubi_metrics
+from tools.art.ubi_metrics_tools import compute_ubi_metrics  # noqa: E402
 
 logger = get_logger(__name__)
 

--- a/src/agents/art/specialized_agents.py
+++ b/src/agents/art/specialized_agents.py
@@ -254,7 +254,6 @@ not the raw ctr decimal.
 """
 
 
-
 # Global variable to store the authenticated MCPClient and its resolved tools.
 # Specialized agents use the resolved tools (not the MCPClient directly) to
 # avoid triggering a second start() on an already-running session.
@@ -297,7 +296,9 @@ async def hypothesis_agent(query: str) -> str:
         str: Hypothesis with reasoning and recommendations for solving the issue
     """
     if not _mcp_tools:
-        return "Error: MCP tools not configured. Please initialize MCP connection first."
+        return (
+            "Error: MCP tools not configured. Please initialize MCP connection first."
+        )
 
     try:
         # Use resolved tools (not MCPClient directly) to avoid calling
@@ -336,7 +337,9 @@ async def evaluation_agent(query: str) -> str:
         str: Evaluation results with metrics, analysis, and recommendations
     """
     if not _mcp_tools:
-        return "Error: MCP tools not configured. Please initialize MCP connection first."
+        return (
+            "Error: MCP tools not configured. Please initialize MCP connection first."
+        )
 
     try:
         # Use resolved tools (not MCPClient directly) to avoid calling
@@ -375,7 +378,9 @@ async def user_behavior_analysis_agent(query: str) -> str:
         str: Analysis results with metrics, patterns, and actionable insights
     """
     if not _mcp_tools:
-        return "Error: MCP tools not configured. Please initialize MCP connection first."
+        return (
+            "Error: MCP tools not configured. Please initialize MCP connection first."
+        )
 
     try:
         # Use resolved tools (not MCPClient directly) to avoid calling

--- a/src/server/__init__.py
+++ b/src/server/__init__.py
@@ -3,10 +3,9 @@
 Provides AG-UI protocol server for the multi-agent system.
 """
 
-from importlib.metadata import PackageNotFoundError, version
+from importlib.metadata import version
 
 from server.agent_orchestrator import AgentOrchestrator
-
 
 __version__ = version("opensearch-agent-server")
 

--- a/src/server/ag_ui_app.py
+++ b/src/server/ag_ui_app.py
@@ -322,21 +322,29 @@ def create_app(config_override: ServerConfig | None = None) -> FastAPI:
         opensearch_url = config_resolved.opensearch_url
 
         # Register ART agent (search relevance page)
-        registry.register(AgentRegistration(
-            name="art",
-            description="Search Relevance Tuning agent (ART) — hypothesis generation, "
-            "evaluation, and UBI analysis.",
-            page_contexts=["search_overview", "search-relevance", "searchRelevance"],
-            is_default=False,
-        ))
+        registry.register(
+            AgentRegistration(
+                name="art",
+                description="Search Relevance Tuning agent (ART) — hypothesis generation, "
+                "evaluation, and UBI analysis.",
+                page_contexts=[
+                    "search_overview",
+                    "search-relevance",
+                    "searchRelevance",
+                ],
+                is_default=False,
+            )
+        )
 
         # Register default agent (handles all unmatched page contexts)
-        registry.register(AgentRegistration(
-            name="default",
-            description="General OpenSearch assistant with MCP tools",
-            page_contexts=[],
-            is_default=True,
-        ))
+        registry.register(
+            AgentRegistration(
+                name="default",
+                description="General OpenSearch assistant with MCP tools",
+                page_contexts=[],
+                is_default=True,
+            )
+        )
 
         log_info_event(
             logger,
@@ -365,7 +373,9 @@ def create_app(config_override: ServerConfig | None = None) -> FastAPI:
                 context_text = "\n".join(
                     f"{ctx.description}: {ctx.value}" for ctx in input_data.context
                 )
-                return f"{user_message}\n\n## Context from the application\n{context_text}"
+                return (
+                    f"{user_message}\n\n## Context from the application\n{context_text}"
+                )
             return user_message
 
         context_config = StrandsAgentConfig(state_context_builder=_page_context_builder)
@@ -656,6 +666,7 @@ async def cancel_run(run_id: str, request: Request) -> CancelRunResponse:
         persistence=persistence, run_id=run_id, request=request
     )
 
+
 @app.post("/invoke", tags=["invoke"])
 @rate_limit
 async def invoke(
@@ -667,6 +678,7 @@ async def invoke(
     Runs the agent to completion and returns the final response as JSON.
     Accepts a string query or message list (Strands Agent interface).
     """
+
     def _bad_request(message: str) -> JSONResponse:
         return JSONResponse(
             status_code=400,
@@ -703,7 +715,8 @@ async def invoke(
 
     if messages:
         if not isinstance(messages, list) or not all(
-            isinstance(m, dict) and isinstance(m.get("role"), str)
+            isinstance(m, dict)
+            and isinstance(m.get("role"), str)
             and isinstance(m.get("content"), str)
             for m in messages
         ):
@@ -711,8 +724,7 @@ async def invoke(
                 "'messages' must be a list of {role: str, content: str} objects."
             )
         prompt: str | list[dict] = [
-            {"role": m["role"], "content": [{"text": m["content"]}]}
-            for m in messages
+            {"role": m["role"], "content": [{"text": m["content"]}]} for m in messages
         ]
     elif not isinstance(query, str):
         return _bad_request("'query' must be a string.")

--- a/src/server/agent_orchestrator.py
+++ b/src/server/agent_orchestrator.py
@@ -286,7 +286,7 @@ class AgentOrchestrator:
             # Only a missing result is empty; falsey-but-valid values (0, False)
             # are still stringified.
             return str(result) if result is not None else ""
-        except asyncio.TimeoutError:
+        except TimeoutError:
             agent.cancel()
             raise TimeoutError(
                 f"Agent '{agent_name}' did not complete within {timeout}s."

--- a/src/server/auth_middleware.py
+++ b/src/server/auth_middleware.py
@@ -53,7 +53,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Callable
-from enum import Enum
+from enum import StrEnum
 from typing import TypedDict
 
 import jwt
@@ -69,14 +69,14 @@ from utils.logging_helpers import get_logger, log_info_event, log_warning_event
 logger = get_logger(__name__)
 
 
-class AuthMode(str, Enum):
+class AuthMode(StrEnum):
     """Authentication mode enumeration."""
 
     STRICT = "strict"
     PERMISSIVE = "permissive"
 
 
-class AuthStrategy(str, Enum):
+class AuthStrategy(StrEnum):
     """Authentication strategy enumeration."""
 
     HEADER = "header"

--- a/src/server/error_recovery.py
+++ b/src/server/error_recovery.py
@@ -45,7 +45,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any, TypeVar
+from typing import Any
 
 from server.exceptions import NotFoundError, PersistenceNotEnabledError
 from utils.logging_helpers import (
@@ -55,9 +55,6 @@ from utils.logging_helpers import (
 )
 
 logger = get_logger(__name__)
-
-T = TypeVar("T")
-R = TypeVar("R")
 
 __all__ = [
     # Partial success
@@ -112,7 +109,7 @@ class PartialSuccessResult:
         return self.success_count / self.total
 
 
-def execute_with_partial_success(
+def execute_with_partial_success[T, R](
     items: list[T],
     operation: Callable[[T], R],
     operation_name: str = "batch_operation",
@@ -206,7 +203,7 @@ def execute_with_partial_success(
     return result
 
 
-async def execute_with_partial_success_async(
+async def execute_with_partial_success_async[T](
     items: list[T],
     operation: Callable[[T], Any],
     operation_name: str = "batch_operation",
@@ -289,7 +286,7 @@ async def execute_with_partial_success_async(
     return result
 
 
-def execute_with_fallback(
+def execute_with_fallback[T](
     operation: Callable[[], T],
     fallback: Callable[[], T],
     operation_name: str | None = None,
@@ -543,7 +540,7 @@ def create_fallback_events_response(
     }
 
 
-def handle_read_operation_with_fallback(
+def handle_read_operation_with_fallback[T](
     operation_name: str,
     operation_func: Callable[..., T],
     fallback_func: Callable[[], T],

--- a/src/server/utils.py
+++ b/src/server/utils.py
@@ -342,7 +342,7 @@ def require_authenticated_if_auth_enabled(request: Request | None) -> None:
     raise UnauthorizedError("Authentication required")
 
 
-async def safe_persistence_operation_async(
+async def safe_persistence_operation_async[T](
     operation_name: str, operation_func: Callable[..., T], *args: Any, **kwargs: Any
 ) -> T | None:
     """Safely execute a persistence write operation with retry logic for transient errors.
@@ -446,7 +446,7 @@ async def safe_persistence_operation_async(
         return None
 
 
-def safe_persistence_operation(
+def safe_persistence_operation[T](
     operation_name: str, operation_func: Callable[..., T], *args: Any, **kwargs: Any
 ) -> T | None:
     """Safely execute a persistence write operation with error handling.
@@ -527,7 +527,7 @@ def safe_persistence_operation(
         return None
 
 
-def handle_persistence_read_operation(
+def handle_persistence_read_operation[T](
     operation_name: str,
     operation_func: Callable[..., T],
     error_event_name: str,

--- a/src/server/utils.py
+++ b/src/server/utils.py
@@ -666,5 +666,3 @@ def parse_json_with_fallback(
                 exc_info=True,
             )
             return fallback_value if fallback_value is not None else text_content
-
-

--- a/src/tools/art/ubi_metrics_tools.py
+++ b/src/tools/art/ubi_metrics_tools.py
@@ -25,7 +25,9 @@ def _parse_buckets(raw: str, label: str) -> list[dict[str, Any]]:
     except json.JSONDecodeError as exc:
         raise ValueError(f"Invalid JSON for {label}: {exc}") from exc
     if not isinstance(data, list):
-        raise ValueError(f"{label} must be a JSON array of bucket objects, got {type(data).__name__}")
+        raise ValueError(
+            f"{label} must be a JSON array of bucket objects, got {type(data).__name__}"
+        )
     return data
 
 
@@ -117,7 +119,9 @@ def compute_ubi_metrics(
     if impression_buckets is not None and click_query_id_buckets is not None:
         try:
             imp_buckets = _parse_buckets(impression_buckets, "impression_buckets")
-            clk_buckets = _parse_buckets(click_query_id_buckets, "click_query_id_buckets")
+            clk_buckets = _parse_buckets(
+                click_query_id_buckets, "click_query_id_buckets"
+            )
         except ValueError as exc:
             return json.dumps({"error": str(exc)})
 
@@ -143,7 +147,9 @@ def compute_ubi_metrics(
             if not query_text:
                 skipped += 1
                 continue
-            clicks_by_query[query_text] = clicks_by_query.get(query_text, 0) + click_count
+            clicks_by_query[query_text] = (
+                clicks_by_query.get(query_text, 0) + click_count
+            )
 
         if skipped:
             results["skipped_click_buckets"] = skipped
@@ -159,13 +165,15 @@ def compute_ubi_metrics(
             impressions = impressions_by_query.get(qt, 0)
             clicks = clicks_by_query.get(qt, 0)
             ctr = clicks / impressions if impressions > 0 else 0.0
-            per_query.append({
-                "query": qt,
-                "impressions": impressions,
-                "clicks": clicks,
-                "ctr": round(ctr, 4),
-                "ctr_pct": f"{ctr * 100:.2f}%",
-            })
+            per_query.append(
+                {
+                    "query": qt,
+                    "impressions": impressions,
+                    "clicks": clicks,
+                    "ctr": round(ctr, 4),
+                    "ctr_pct": f"{ctr * 100:.2f}%",
+                }
+            )
 
         per_query.sort(key=lambda x: x["ctr"], reverse=True)
         results["per_query_count"] = len(per_query)

--- a/src/utils/obo_context.py
+++ b/src/utils/obo_context.py
@@ -34,7 +34,7 @@ Usage::
 from __future__ import annotations
 
 import threading
-from typing import Generator
+from collections.abc import Generator
 
 import httpx
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,9 +14,7 @@ os.environ["OPENSEARCH_URL"] = os.getenv("OPENSEARCH_URL", "http://localhost:920
 
 # Mock AWS credentials for tests (real calls are patched out in unit tests)
 os.environ["AWS_ACCESS_KEY_ID"] = os.getenv("AWS_ACCESS_KEY_ID", "test-key")
-os.environ["AWS_SECRET_ACCESS_KEY"] = os.getenv(
-    "AWS_SECRET_ACCESS_KEY", "test-secret"
-)
+os.environ["AWS_SECRET_ACCESS_KEY"] = os.getenv("AWS_SECRET_ACCESS_KEY", "test-secret")
 os.environ["AWS_REGION"] = os.getenv("AWS_REGION", "us-east-1")
 
 
@@ -49,5 +47,3 @@ def patch_env(monkeypatch: pytest.MonkeyPatch) -> Callable[..., dict[str, str]]:
 def test_opensearch_url() -> str:
     """Returns the test OpenSearch URL (TEST_OPENSEARCH_URL env var, default localhost:9200)."""
     return os.getenv("TEST_OPENSEARCH_URL", "http://localhost:9200")
-
-

--- a/tests/helpers/specialized_agents_helpers.py
+++ b/tests/helpers/specialized_agents_helpers.py
@@ -24,7 +24,9 @@ def patch_hypothesis_agent_dependencies(mock_agent: MagicMock) -> ExitStack:
         patch("agents.art.specialized_agents.Agent", return_value=mock_agent)
     )
     stack.enter_context(patch("agents.art.specialized_agents.create_model"))
-    stack.enter_context(patch("tools.art.experiment_tools.aggregate_experiment_results"))
+    stack.enter_context(
+        patch("tools.art.experiment_tools.aggregate_experiment_results")
+    )
     return stack
 
 
@@ -42,7 +44,9 @@ def patch_evaluation_agent_dependencies(mock_agent: MagicMock) -> ExitStack:
         patch("agents.art.specialized_agents.Agent", return_value=mock_agent)
     )
     stack.enter_context(patch("agents.art.specialized_agents.create_model"))
-    stack.enter_context(patch("tools.art.experiment_tools.aggregate_experiment_results"))
+    stack.enter_context(
+        patch("tools.art.experiment_tools.aggregate_experiment_results")
+    )
     return stack
 
 

--- a/tests/integration/test_specialized_agents.py
+++ b/tests/integration/test_specialized_agents.py
@@ -244,8 +244,6 @@ class TestUserBehaviorAnalysisAgent:
             assert "Rate limit" in result or "429" in result
 
 
-
-
 @pytest.mark.integration
 class TestSpecializedAgentsErrorHandling:
     """Additional error handling tests for specialized agents."""
@@ -286,9 +284,7 @@ class TestSpecializedAgentsErrorHandling:
         mock_agent = MagicMock()
         # Simulate timeout during agent invocation
         mock_agent.invoke_async = AsyncMock(
-            side_effect=TimeoutError(
-                "Agent execution timed out after 30 minutes"
-            )
+            side_effect=TimeoutError("Agent execution timed out after 30 minutes")
         )
 
         with patch_evaluation_agent_dependencies(mock_agent):
@@ -300,7 +296,6 @@ class TestSpecializedAgentsErrorHandling:
             assert "Error in evaluation" in result
             assert "timed out" in result.lower() or "timeout" in result.lower()
             mock_agent.invoke_async.assert_called_once()
-
 
     @pytest.mark.asyncio
     async def test_user_behavior_agent_missing_data(self):

--- a/tests/integration/test_specialized_agents.py
+++ b/tests/integration/test_specialized_agents.py
@@ -8,13 +8,13 @@ from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
-from agents.art import specialized_agents
 from helpers.specialized_agents_helpers import (
     patch_evaluation_agent_dependencies,
     patch_hypothesis_agent_dependencies,
     patch_ubi_agent_dependencies,
 )
+
+from agents.art import specialized_agents
 
 pytestmark = pytest.mark.integration
 
@@ -278,7 +278,6 @@ class TestSpecializedAgentsErrorHandling:
     @pytest.mark.asyncio
     async def test_evaluation_agent_timeout(self):
         """Test evaluation agent timeout handling."""
-        import asyncio
 
         from agents.art import specialized_agents
 
@@ -287,7 +286,7 @@ class TestSpecializedAgentsErrorHandling:
         mock_agent = MagicMock()
         # Simulate timeout during agent invocation
         mock_agent.invoke_async = AsyncMock(
-            side_effect=asyncio.TimeoutError(
+            side_effect=TimeoutError(
                 "Agent execution timed out after 30 minutes"
             )
         )

--- a/tests/unit/test_agentic_search_agent.py
+++ b/tests/unit/test_agentic_search_agent.py
@@ -42,7 +42,9 @@ class _StubClient:
     """Stands in for the OpenSearch client; records the mapping fetch."""
 
     def __init__(self, mapping=None):
-        self._mapping = mapping if mapping is not None else {"products": {"mappings": {}}}
+        self._mapping = (
+            mapping if mapping is not None else {"products": {"mappings": {}}}
+        )
         self.fetched = []
 
     class _Indices:

--- a/tests/unit/test_direct_dsl_strategy.py
+++ b/tests/unit/test_direct_dsl_strategy.py
@@ -21,7 +21,9 @@ class _BedrockLikeModel:
     """Has a ``client`` exposing ``converse_stream`` (the forced-tool capability)."""
 
     class _Client:
-        def converse_stream(self, **kwargs):  # pragma: no cover - never called (stubbed)
+        def converse_stream(
+            self, **kwargs
+        ):  # pragma: no cover - never called (stubbed)
             raise AssertionError("real converse_stream should be stubbed out")
 
     client = _Client()

--- a/tests/unit/test_experiment_tools.py
+++ b/tests/unit/test_experiment_tools.py
@@ -19,7 +19,9 @@ from src.tools.art.experiment_tools import (
 pytestmark = pytest.mark.unit
 
 
-def _pairwise_experiment(experiment_id="exp1", status="COMPLETED", results=None, search_config_list=None):
+def _pairwise_experiment(
+    experiment_id="exp1", status="COMPLETED", results=None, search_config_list=None
+):
     """Build a minimal pairwise experiment document."""
     doc = {
         "id": experiment_id,
@@ -79,7 +81,9 @@ class TestAggregateExperimentResults:
     @pytest.mark.asyncio
     async def test_error_status(self):
         """Returns error details when experiment status is ERROR."""
-        result = await aggregate_experiment_results(_pairwise_experiment(status="ERROR"))
+        result = await aggregate_experiment_results(
+            _pairwise_experiment(status="ERROR")
+        )
         result_data = json.loads(result)
         assert result_data["status"] == "ERROR"
         assert "error_message" in result_data
@@ -88,7 +92,9 @@ class TestAggregateExperimentResults:
     @pytest.mark.asyncio
     async def test_pending_status(self):
         """Returns in-progress message for PENDING status."""
-        result = await aggregate_experiment_results(_pairwise_experiment(status="PENDING"))
+        result = await aggregate_experiment_results(
+            _pairwise_experiment(status="PENDING")
+        )
         result_data = json.loads(result)
         assert result_data["status"] == "PENDING"
         assert "still pending" in result_data["message"].lower()
@@ -96,7 +102,9 @@ class TestAggregateExperimentResults:
     @pytest.mark.asyncio
     async def test_running_status(self):
         """Returns in-progress message for RUNNING status."""
-        result = await aggregate_experiment_results(_pairwise_experiment(status="RUNNING"))
+        result = await aggregate_experiment_results(
+            _pairwise_experiment(status="RUNNING")
+        )
         result_data = json.loads(result)
         assert result_data["status"] == "RUNNING"
         assert "message" in result_data
@@ -104,7 +112,9 @@ class TestAggregateExperimentResults:
     @pytest.mark.asyncio
     async def test_unknown_status(self):
         """Returns not-available message for unrecognised status."""
-        result = await aggregate_experiment_results(_pairwise_experiment(status="CANCELLED"))
+        result = await aggregate_experiment_results(
+            _pairwise_experiment(status="CANCELLED")
+        )
         result_data = json.loads(result)
         assert result_data["status"] == "CANCELLED"
         assert "Results not available" in result_data["message"]
@@ -157,7 +167,9 @@ class TestAggregateExperimentResults:
                 ],
             },
         ]
-        result = await aggregate_experiment_results(_pairwise_experiment(results=results))
+        result = await aggregate_experiment_results(
+            _pairwise_experiment(results=results)
+        )
         result_data = json.loads(result)
 
         assert result_data["experiment_id"] == "exp1"
@@ -191,7 +203,9 @@ class TestAggregateExperimentResults:
                 "snapshots": [],
             }
         ]
-        result = await aggregate_experiment_results(_pairwise_experiment(results=results))
+        result = await aggregate_experiment_results(
+            _pairwise_experiment(results=results)
+        )
         result_data = json.loads(result)
         assert result_data["total_queries"] == 1
         assert "rbo50" in result_data["aggregate_metrics"]
@@ -201,7 +215,9 @@ class TestAggregateExperimentResults:
     async def test_pairwise_empty_metrics_list(self):
         """Empty metrics list produces no aggregate_metrics."""
         results = [{"query_text": "test", "metrics": [], "snapshots": []}]
-        result = await aggregate_experiment_results(_pairwise_experiment(results=results))
+        result = await aggregate_experiment_results(
+            _pairwise_experiment(results=results)
+        )
         result_data = json.loads(result)
         assert result_data["aggregate_metrics"] == {}
         assert result_data["primary_metric"] is None
@@ -214,14 +230,16 @@ class TestAggregateExperimentResults:
                 "query_text": "test",
                 "metrics": [
                     {"metric": "jaccard", "value": 0.8},
-                    {"metric": "rbo50"},           # missing value → None, skipped for agg
-                    {"value": 0.5},                # missing name → skipped entirely
-                    {},                            # empty → skipped
+                    {"metric": "rbo50"},  # missing value → None, skipped for agg
+                    {"value": 0.5},  # missing name → skipped entirely
+                    {},  # empty → skipped
                 ],
                 "snapshots": [],
             }
         ]
-        result = await aggregate_experiment_results(_pairwise_experiment(results=results))
+        result = await aggregate_experiment_results(
+            _pairwise_experiment(results=results)
+        )
         result_data = json.loads(result)
         assert result_data["total_queries"] == 1
         assert "jaccard" in result_data["aggregate_metrics"]
@@ -231,15 +249,21 @@ class TestAggregateExperimentResults:
     async def test_pairwise_missing_query_text(self):
         """Missing query_text defaults to empty string."""
         results = [{"metrics": [{"metric": "jaccard", "value": 0.8}], "snapshots": []}]
-        result = await aggregate_experiment_results(_pairwise_experiment(results=results))
+        result = await aggregate_experiment_results(
+            _pairwise_experiment(results=results)
+        )
         result_data = json.loads(result)
         assert result_data["per_query_results"][0]["query_text"] == ""
 
     @pytest.mark.asyncio
     async def test_pairwise_missing_snapshots(self):
         """Missing snapshots field defaults to empty list."""
-        results = [{"query_text": "test", "metrics": [{"metric": "jaccard", "value": 0.8}]}]
-        result = await aggregate_experiment_results(_pairwise_experiment(results=results))
+        results = [
+            {"query_text": "test", "metrics": [{"metric": "jaccard", "value": 0.8}]}
+        ]
+        result = await aggregate_experiment_results(
+            _pairwise_experiment(results=results)
+        )
         result_data = json.loads(result)
         assert result_data["per_query_results"][0]["snapshots"] == []
 
@@ -247,9 +271,15 @@ class TestAggregateExperimentResults:
     async def test_pairwise_single_value_stdev_zero(self):
         """Single-query experiment reports std_dev of 0."""
         results = [
-            {"query_text": "test", "metrics": [{"metric": "jaccard", "value": 0.8}], "snapshots": []}
+            {
+                "query_text": "test",
+                "metrics": [{"metric": "jaccard", "value": 0.8}],
+                "snapshots": [],
+            }
         ]
-        result = await aggregate_experiment_results(_pairwise_experiment(results=results))
+        result = await aggregate_experiment_results(
+            _pairwise_experiment(results=results)
+        )
         result_data = json.loads(result)
         assert result_data["aggregate_metrics"]["jaccard"]["std_dev"] == 0
 
@@ -257,10 +287,20 @@ class TestAggregateExperimentResults:
     async def test_pairwise_negative_metric_values(self):
         """Negative metric values are handled in min/max correctly."""
         results = [
-            {"query_text": "t1", "metrics": [{"metric": "jaccard", "value": -0.5}], "snapshots": []},
-            {"query_text": "t2", "metrics": [{"metric": "jaccard", "value": 0.8}], "snapshots": []},
+            {
+                "query_text": "t1",
+                "metrics": [{"metric": "jaccard", "value": -0.5}],
+                "snapshots": [],
+            },
+            {
+                "query_text": "t2",
+                "metrics": [{"metric": "jaccard", "value": 0.8}],
+                "snapshots": [],
+            },
         ]
-        result = await aggregate_experiment_results(_pairwise_experiment(results=results))
+        result = await aggregate_experiment_results(
+            _pairwise_experiment(results=results)
+        )
         result_data = json.loads(result)
         assert result_data["aggregate_metrics"]["jaccard"]["min"] == -0.5
         assert result_data["aggregate_metrics"]["jaccard"]["max"] == 0.8
@@ -269,10 +309,16 @@ class TestAggregateExperimentResults:
     async def test_pairwise_all_same_values(self):
         """All-equal metrics produce zero std_dev and equal mean/median/min/max."""
         results = [
-            {"query_text": f"q{i}", "metrics": [{"metric": "jaccard", "value": 0.5}], "snapshots": []}
+            {
+                "query_text": f"q{i}",
+                "metrics": [{"metric": "jaccard", "value": 0.5}],
+                "snapshots": [],
+            }
             for i in range(3)
         ]
-        result = await aggregate_experiment_results(_pairwise_experiment(results=results))
+        result = await aggregate_experiment_results(
+            _pairwise_experiment(results=results)
+        )
         result_data = json.loads(result)
         agg = result_data["aggregate_metrics"]["jaccard"]
         assert agg["mean"] == agg["median"] == agg["min"] == agg["max"] == 0.5
@@ -289,13 +335,21 @@ class TestAggregateExperimentResults:
                     {"metric": "rbo50", "value": 0.4 + (i % 10) * 0.05},
                 ],
                 "snapshots": [
-                    {"searchConfigurationId": "config1", "docIds": [f"doc{j}" for j in range(10)]},
-                    {"searchConfigurationId": "config2", "docIds": [f"doc{j+10}" for j in range(10)]},
+                    {
+                        "searchConfigurationId": "config1",
+                        "docIds": [f"doc{j}" for j in range(10)],
+                    },
+                    {
+                        "searchConfigurationId": "config2",
+                        "docIds": [f"doc{j + 10}" for j in range(10)],
+                    },
                 ],
             }
             for i in range(500)
         ]
-        result = await aggregate_experiment_results(_pairwise_experiment(results=results))
+        result = await aggregate_experiment_results(
+            _pairwise_experiment(results=results)
+        )
         result_data = json.loads(result)
         assert result_data["total_queries"] == 500
         assert len(result_data["per_query_results"]) == 500
@@ -328,7 +382,9 @@ class TestAggregateExperimentResults:
         assert result_data["type"] == "POINTWISE_EVALUATION"
         assert result_data["total_queries"] == 2
         assert "NDCG@10" in result_data["aggregate_metrics"]
-        assert result_data["aggregate_metrics"]["NDCG@10"]["mean"] == round((0.85 + 0.70) / 2, 4)
+        assert result_data["aggregate_metrics"]["NDCG@10"]["mean"] == round(
+            (0.85 + 0.70) / 2, 4
+        )
 
     @pytest.mark.asyncio
     async def test_pointwise_empty_hits(self):
@@ -382,7 +438,14 @@ class TestAggregateExperimentResults:
     @pytest.mark.asyncio
     async def test_pointwise_empty_metrics_list(self):
         """Empty metrics list produces no aggregate_metrics."""
-        hits = [{"searchText": "test", "metrics": [], "documentIds": ["doc1"], "searchConfigurationId": "config1"}]
+        hits = [
+            {
+                "searchText": "test",
+                "metrics": [],
+                "documentIds": ["doc1"],
+                "searchConfigurationId": "config1",
+            }
+        ]
         result = await aggregate_experiment_results(
             _pointwise_experiment(), evaluation_results=_eval_results(hits)
         )
@@ -392,7 +455,13 @@ class TestAggregateExperimentResults:
     @pytest.mark.asyncio
     async def test_pointwise_missing_search_text(self):
         """Missing searchText defaults to empty string."""
-        hits = [{"metrics": [{"metric": "NDCG@10", "value": 0.8}], "documentIds": ["doc1"], "searchConfigurationId": "config1"}]
+        hits = [
+            {
+                "metrics": [{"metric": "NDCG@10", "value": 0.8}],
+                "documentIds": ["doc1"],
+                "searchConfigurationId": "config1",
+            }
+        ]
         result = await aggregate_experiment_results(
             _pointwise_experiment(), evaluation_results=_eval_results(hits)
         )
@@ -402,7 +471,13 @@ class TestAggregateExperimentResults:
     @pytest.mark.asyncio
     async def test_pointwise_missing_document_ids(self):
         """Missing documentIds defaults to empty list."""
-        hits = [{"searchText": "test", "metrics": [{"metric": "NDCG@10", "value": 0.8}], "searchConfigurationId": "config1"}]
+        hits = [
+            {
+                "searchText": "test",
+                "metrics": [{"metric": "NDCG@10", "value": 0.8}],
+                "searchConfigurationId": "config1",
+            }
+        ]
         result = await aggregate_experiment_results(
             _pointwise_experiment(), evaluation_results=_eval_results(hits)
         )
@@ -412,7 +487,13 @@ class TestAggregateExperimentResults:
     @pytest.mark.asyncio
     async def test_pointwise_missing_search_configuration_id(self):
         """Missing searchConfigurationId defaults to empty string."""
-        hits = [{"searchText": "test", "metrics": [{"metric": "NDCG@10", "value": 0.8}], "documentIds": ["doc1"]}]
+        hits = [
+            {
+                "searchText": "test",
+                "metrics": [{"metric": "NDCG@10", "value": 0.8}],
+                "documentIds": ["doc1"],
+            }
+        ]
         result = await aggregate_experiment_results(
             _pointwise_experiment(), evaluation_results=_eval_results(hits)
         )
@@ -422,7 +503,14 @@ class TestAggregateExperimentResults:
     @pytest.mark.asyncio
     async def test_pointwise_fallback_primary_metric(self):
         """Falls back to first available metric when NDCG@10 is absent."""
-        hits = [{"searchText": "test", "metrics": [{"metric": "MRR", "value": 0.8}], "documentIds": ["doc1"], "searchConfigurationId": "config1"}]
+        hits = [
+            {
+                "searchText": "test",
+                "metrics": [{"metric": "MRR", "value": 0.8}],
+                "documentIds": ["doc1"],
+                "searchConfigurationId": "config1",
+            }
+        ]
         result = await aggregate_experiment_results(
             _pointwise_experiment(), evaluation_results=_eval_results(hits)
         )
@@ -432,7 +520,14 @@ class TestAggregateExperimentResults:
     @pytest.mark.asyncio
     async def test_pointwise_single_value_stdev_zero(self):
         """Single-query pointwise experiment reports std_dev of 0."""
-        hits = [{"searchText": "test", "metrics": [{"metric": "NDCG@10", "value": 0.8}], "documentIds": ["doc1"], "searchConfigurationId": "config1"}]
+        hits = [
+            {
+                "searchText": "test",
+                "metrics": [{"metric": "NDCG@10", "value": 0.8}],
+                "documentIds": ["doc1"],
+                "searchConfigurationId": "config1",
+            }
+        ]
         result = await aggregate_experiment_results(
             _pointwise_experiment(), evaluation_results=_eval_results(hits)
         )
@@ -447,9 +542,9 @@ class TestAggregateExperimentResults:
                 "searchText": "test",
                 "metrics": [
                     {"metric": "NDCG@10", "value": 0.8},
-                    {"metric": "MRR"},       # missing value
-                    {"value": 0.5},          # missing name
-                    {},                      # empty
+                    {"metric": "MRR"},  # missing value
+                    {"value": 0.5},  # missing name
+                    {},  # empty
                 ],
                 "documentIds": ["doc1"],
                 "searchConfigurationId": "config1",
@@ -489,7 +584,11 @@ class TestAggregateExperimentResults:
         import asyncio
 
         results_data = [
-            {"query_text": "test", "metrics": [{"metric": "jaccard", "value": 0.8}], "snapshots": []}
+            {
+                "query_text": "test",
+                "metrics": [{"metric": "jaccard", "value": 0.8}],
+                "snapshots": [],
+            }
         ]
         exp = _pairwise_experiment(results=results_data)
         results = await asyncio.gather(

--- a/tests/unit/test_invoke_endpoint.py
+++ b/tests/unit/test_invoke_endpoint.py
@@ -73,9 +73,7 @@ class TestInvokeEndpoint:
 
     def test_explicit_agent_name(self, client, mock_orchestrator):
         """Agent name from request body is passed to orchestrator."""
-        response = client.post(
-            "/invoke", json={"query": "hi", "agent": "decomposer"}
-        )
+        response = client.post("/invoke", json={"query": "hi", "agent": "decomposer"})
 
         assert response.status_code == 200
         mock_orchestrator.invoke.assert_called_once_with(
@@ -105,9 +103,7 @@ class TestInvokeEndpoint:
             )
         )
 
-        response = client.post(
-            "/invoke", json={"query": "hi", "agent": "bad"}
-        )
+        response = client.post("/invoke", json={"query": "hi", "agent": "bad"})
 
         assert response.status_code == 500
         body = response.json()
@@ -117,9 +113,7 @@ class TestInvokeEndpoint:
 
     def test_error_response_has_no_traceback(self, client, mock_orchestrator):
         """Error responses must not leak tracebacks."""
-        mock_orchestrator.invoke = AsyncMock(
-            side_effect=ValueError("something broke")
-        )
+        mock_orchestrator.invoke = AsyncMock(side_effect=ValueError("something broke"))
 
         response = client.post("/invoke", json={"query": "hi"})
 
@@ -169,9 +163,7 @@ class TestInvokeEndpoint:
 
     def test_custom_timeout_passed_to_orchestrator(self, client, mock_orchestrator):
         """Custom timeout value from request body is passed to orchestrator."""
-        response = client.post(
-            "/invoke", json={"query": "hi", "timeout": 300}
-        )
+        response = client.post("/invoke", json={"query": "hi", "timeout": 300})
 
         assert response.status_code == 200
         mock_orchestrator.invoke.assert_called_once_with(

--- a/tests/unit/test_model_factory.py
+++ b/tests/unit/test_model_factory.py
@@ -30,7 +30,9 @@ class TestCreateModelBedrock:
     def _use_bedrock(self, monkeypatch):
         monkeypatch.delenv("OLLAMA_MODEL", raising=False)
         monkeypatch.setenv("BEDROCK_MODEL", "arn:aws:bedrock:us-east-1:123:model/test")
-        monkeypatch.setenv("BEDROCK_SMALL_MODEL", "arn:aws:bedrock:us-east-1:123:model/haiku")
+        monkeypatch.setenv(
+            "BEDROCK_SMALL_MODEL", "arn:aws:bedrock:us-east-1:123:model/haiku"
+        )
 
     @patch("strands.models.bedrock.BedrockModel.__init__", return_value=None)
     @patch("boto3.Session")
@@ -74,7 +76,9 @@ class TestCreateModelBedrockFallbacks:
 
     @patch("strands.models.bedrock.BedrockModel.__init__", return_value=None)
     @patch("boto3.Session")
-    def test_default_tier_falls_back_to_default_model_id(self, mock_session_cls, mock_init):
+    def test_default_tier_falls_back_to_default_model_id(
+        self, mock_session_cls, mock_init
+    ):
         """Default tier with no env vars uses _DEFAULT_BEDROCK_MODEL_ID."""
         mock_session = MagicMock()
         mock_session_cls.return_value = mock_session
@@ -89,9 +93,13 @@ class TestCreateModelBedrockFallbacks:
 
     @patch("strands.models.bedrock.BedrockModel.__init__", return_value=None)
     @patch("boto3.Session")
-    def test_small_tier_falls_back_to_bedrock_model(self, mock_session_cls, mock_init, monkeypatch):
+    def test_small_tier_falls_back_to_bedrock_model(
+        self, mock_session_cls, mock_init, monkeypatch
+    ):
         """Small tier with only BEDROCK_MODEL set falls back to it."""
-        monkeypatch.setenv("BEDROCK_MODEL", "arn:aws:bedrock:us-east-1:123:model/sonnet")
+        monkeypatch.setenv(
+            "BEDROCK_MODEL", "arn:aws:bedrock:us-east-1:123:model/sonnet"
+        )
         mock_session = MagicMock()
         mock_session_cls.return_value = mock_session
 
@@ -105,7 +113,9 @@ class TestCreateModelBedrockFallbacks:
 
     @patch("strands.models.bedrock.BedrockModel.__init__", return_value=None)
     @patch("boto3.Session")
-    def test_small_tier_falls_back_to_default_model_id(self, mock_session_cls, mock_init):
+    def test_small_tier_falls_back_to_default_model_id(
+        self, mock_session_cls, mock_init
+    ):
         """Small tier with neither env var set uses _DEFAULT_BEDROCK_MODEL_ID."""
         mock_session = MagicMock()
         mock_session_cls.return_value = mock_session
@@ -120,9 +130,14 @@ class TestCreateModelBedrockFallbacks:
 
     @patch("strands.models.bedrock.BedrockModel.__init__", return_value=None)
     @patch("boto3.Session")
-    def test_default_tier_falls_back_to_legacy_env_var(self, mock_session_cls, mock_init, monkeypatch):
+    def test_default_tier_falls_back_to_legacy_env_var(
+        self, mock_session_cls, mock_init, monkeypatch
+    ):
         """Default tier with legacy BEDROCK_INFERENCE_PROFILE_ARN still works."""
-        monkeypatch.setenv("BEDROCK_INFERENCE_PROFILE_ARN", "arn:aws:bedrock:us-east-1:123:inference-profile/my-profile")
+        monkeypatch.setenv(
+            "BEDROCK_INFERENCE_PROFILE_ARN",
+            "arn:aws:bedrock:us-east-1:123:inference-profile/my-profile",
+        )
         mock_session = MagicMock()
         mock_session_cls.return_value = mock_session
 
@@ -136,9 +151,14 @@ class TestCreateModelBedrockFallbacks:
 
     @patch("strands.models.bedrock.BedrockModel.__init__", return_value=None)
     @patch("boto3.Session")
-    def test_small_tier_falls_back_to_legacy_haiku_env_var(self, mock_session_cls, mock_init, monkeypatch):
+    def test_small_tier_falls_back_to_legacy_haiku_env_var(
+        self, mock_session_cls, mock_init, monkeypatch
+    ):
         """Small tier with legacy BEDROCK_HAIKU_INFERENCE_PROFILE_ARN still works."""
-        monkeypatch.setenv("BEDROCK_HAIKU_INFERENCE_PROFILE_ARN", "arn:aws:bedrock:us-east-1:123:inference-profile/haiku")
+        monkeypatch.setenv(
+            "BEDROCK_HAIKU_INFERENCE_PROFILE_ARN",
+            "arn:aws:bedrock:us-east-1:123:inference-profile/haiku",
+        )
         mock_session = MagicMock()
         mock_session_cls.return_value = mock_session
 

--- a/tests/unit/test_monitored_tool.py
+++ b/tests/unit/test_monitored_tool.py
@@ -45,7 +45,9 @@ class TestMonitoredToolGracefulDegradation:
     """Tests for graceful degradation when the AG-UI emitter is unavailable."""
 
     @pytest.mark.asyncio
-    async def test_async_tool_executes_without_monitoring_when_emitter_returns_none(self):
+    async def test_async_tool_executes_without_monitoring_when_emitter_returns_none(
+        self,
+    ):
         """Tool runs and returns result when get_ag_ui_emitter returns None."""
         with patch(_AG_UI_PATCH, return_value=None):
 

--- a/tests/unit/test_orchestrator_concurrency.py
+++ b/tests/unit/test_orchestrator_concurrency.py
@@ -10,7 +10,7 @@ Tests verify that the per-request agent creation fix:
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 

--- a/tests/unit/test_orchestrator_concurrency.py
+++ b/tests/unit/test_orchestrator_concurrency.py
@@ -63,6 +63,7 @@ class TestCredentialIsolation:
     ):
         """Each concurrent request must create its own agent instance."""
         with patch("server.agent_orchestrator.AGUIStrandsAgent") as mock_agui:
+
             async def fake_run(data):
                 await asyncio.sleep(0.05)
                 yield MagicMock(type=MagicMock(value="RUN_FINISHED"))
@@ -92,11 +93,10 @@ class TestCredentialIsolation:
         assert len(orchestrator._agents_created) == 2
 
     @pytest.mark.asyncio
-    async def test_each_request_gets_its_own_token(
-        self, orchestrator, mock_input_data
-    ):
+    async def test_each_request_gets_its_own_token(self, orchestrator, mock_input_data):
         """Each agent instance gets the correct token, not a shared one."""
         with patch("server.agent_orchestrator.AGUIStrandsAgent") as mock_agui:
+
             async def fake_run(data):
                 yield MagicMock(type=MagicMock(value="RUN_FINISHED"))
 
@@ -130,6 +130,7 @@ class TestCredentialIsolation:
     ):
         """Each request must have a different OboAuth instance."""
         with patch("server.agent_orchestrator.AGUIStrandsAgent") as mock_agui:
+
             async def fake_run(data):
                 yield MagicMock(type=MagicMock(value="RUN_FINISHED"))
 
@@ -163,6 +164,7 @@ class TestMcpClientCleanup:
     ):
         """MCP client must be stopped after a successful request."""
         with patch("server.agent_orchestrator.AGUIStrandsAgent") as mock_agui:
+
             async def fake_run(data):
                 yield MagicMock(type=MagicMock(value="RUN_FINISHED"))
 
@@ -177,11 +179,10 @@ class TestMcpClientCleanup:
         agent._mcp_client.stop.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_mcp_client_stopped_on_error(
-        self, orchestrator, mock_input_data
-    ):
+    async def test_mcp_client_stopped_on_error(self, orchestrator, mock_input_data):
         """MCP client must be stopped even if the agent run raises."""
         with patch("server.agent_orchestrator.AGUIStrandsAgent") as mock_agui:
+
             async def failing_run(data):
                 raise RuntimeError("agent exploded")
                 yield  # noqa: unreachable — makes this an async generator
@@ -203,6 +204,7 @@ class TestMcpClientCleanup:
     ):
         """If mcp_client.stop() raises, it should be suppressed."""
         with patch("server.agent_orchestrator.AGUIStrandsAgent") as mock_agui:
+
             async def fake_run(data):
                 yield MagicMock(type=MagicMock(value="RUN_FINISHED"))
 
@@ -222,11 +224,10 @@ class TestMcpClientCleanup:
         # Verify the run completed without error (stop exception suppressed)
 
     @pytest.mark.asyncio
-    async def test_no_mcp_client_does_not_error(
-        self, orchestrator, mock_input_data
-    ):
+    async def test_no_mcp_client_does_not_error(self, orchestrator, mock_input_data):
         """Agent without _mcp_client attribute should not error on cleanup."""
         with patch("server.agent_orchestrator.AGUIStrandsAgent") as mock_agui:
+
             async def fake_run(data):
                 yield MagicMock(type=MagicMock(value="RUN_FINISHED"))
 
@@ -253,11 +254,10 @@ class TestPerRequestAgentCreation:
     """Tests that agents are never cached/shared."""
 
     @pytest.mark.asyncio
-    async def test_factory_called_every_request(
-        self, orchestrator, mock_input_data
-    ):
+    async def test_factory_called_every_request(self, orchestrator, mock_input_data):
         """Factory must be called on every request, not cached."""
         with patch("server.agent_orchestrator.AGUIStrandsAgent") as mock_agui:
+
             async def fake_run(data):
                 yield MagicMock(type=MagicMock(value="RUN_FINISHED"))
 
@@ -281,10 +281,9 @@ class TestInvokeCredentialIsolation:
     """Tests that concurrent /invoke requests get isolated credentials."""
 
     @pytest.mark.asyncio
-    async def test_concurrent_invoke_requests_get_separate_agents(
-        self, orchestrator
-    ):
+    async def test_concurrent_invoke_requests_get_separate_agents(self, orchestrator):
         """Each concurrent invoke request must create its own agent instance."""
+
         async def run_invoke(token):
             return await orchestrator.invoke(
                 prompt="hello",
@@ -322,12 +321,8 @@ class TestInvokeCredentialIsolation:
     @pytest.mark.asyncio
     async def test_invoke_no_shared_obo_auth(self, orchestrator):
         """Each invoke request must have a different OboAuth instance."""
-        await orchestrator.invoke(
-            prompt="hello", agent_name="default", headers=None
-        )
-        await orchestrator.invoke(
-            prompt="hello", agent_name="default", headers=None
-        )
+        await orchestrator.invoke(prompt="hello", agent_name="default", headers=None)
+        await orchestrator.invoke(prompt="hello", agent_name="default", headers=None)
 
         agent_1 = orchestrator._agents_created[0]
         agent_2 = orchestrator._agents_created[1]
@@ -340,9 +335,7 @@ class TestInvokeMcpClientCleanup:
     @pytest.mark.asyncio
     async def test_invoke_mcp_client_stopped_after_success(self, orchestrator):
         """MCP client must be stopped after a successful invoke."""
-        await orchestrator.invoke(
-            prompt="hello", agent_name="default", headers=None
-        )
+        await orchestrator.invoke(prompt="hello", agent_name="default", headers=None)
 
         agent = orchestrator._agents_created[0]
         agent._mcp_client.stop.assert_called_once()
@@ -350,6 +343,7 @@ class TestInvokeMcpClientCleanup:
     @pytest.mark.asyncio
     async def test_invoke_mcp_client_stopped_on_error(self, orchestrator):
         """MCP client must be stopped even if invoke raises."""
+
         # Make the agent call raise
         def failing_agent(prompt):
             raise RuntimeError("agent exploded")
@@ -384,9 +378,7 @@ class TestInvokeMcpClientCleanup:
         orchestrator._agent_factories["default"]["factory"] = factory_no_mcp
 
         # Should not raise
-        await orchestrator.invoke(
-            prompt="hello", agent_name="default", headers=None
-        )
+        await orchestrator.invoke(prompt="hello", agent_name="default", headers=None)
 
     @pytest.mark.asyncio
     async def test_invoke_factory_called_every_request(self, orchestrator):

--- a/tests/unit/test_response_formats.py
+++ b/tests/unit/test_response_formats.py
@@ -23,6 +23,9 @@ def test_wrap_puts_result_string_at_output_result():
 
 def test_wrap_is_verbatim_not_reparsed():
     # The envelope carries the reply as-is; it does not parse or reshape it.
-    assert wrap_inference_results("anything")["inference_results"][0]["output"][0][
-        "result"
-    ] == "anything"
+    assert (
+        wrap_inference_results("anything")["inference_results"][0]["output"][0][
+            "result"
+        ]
+        == "anything"
+    )

--- a/tests/unit/test_skill_loader.py
+++ b/tests/unit/test_skill_loader.py
@@ -67,7 +67,9 @@ class TestBundledOnly:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """If bundled path returns None, loader returns []."""
-        monkeypatch.setattr("agents.skill_loader._bundled_skills_resource", lambda: None)
+        monkeypatch.setattr(
+            "agents.skill_loader._bundled_skills_resource", lambda: None
+        )
         _set_fake_home(monkeypatch, tmp_path / "scratch-home")
         monkeypatch.delenv(_ENV_VAR, raising=False)
 
@@ -84,7 +86,9 @@ class TestBundledOnly:
         """When _bundled_skills_resource() returns None, it contributes no path
         to search — so we should NOT see a path_missing event for it, and
         the loader should simply return []."""
-        monkeypatch.setattr("agents.skill_loader._bundled_skills_resource", lambda: None)
+        monkeypatch.setattr(
+            "agents.skill_loader._bundled_skills_resource", lambda: None
+        )
         _set_fake_home(monkeypatch, tmp_path / "scratch-home")
         monkeypatch.delenv(_ENV_VAR, raising=False)
 

--- a/tests/unit/test_specialized_agents_errors.py
+++ b/tests/unit/test_specialized_agents_errors.py
@@ -86,9 +86,7 @@ class TestSpecializedAgentsErrors:
         mock_agent = MagicMock()
         # Simulate timeout during agent invocation
         mock_agent.invoke_async = AsyncMock(
-            side_effect=TimeoutError(
-                "Agent execution timed out after 30 minutes"
-            )
+            side_effect=TimeoutError("Agent execution timed out after 30 minutes")
         )
 
         with patch_evaluation_agent_dependencies(mock_agent):
@@ -100,7 +98,6 @@ class TestSpecializedAgentsErrors:
             assert "Error in evaluation" in result
             assert "timed out" in result.lower() or "timeout" in result.lower()
             mock_agent.invoke_async.assert_called_once()
-
 
     @pytest.mark.asyncio
     async def test_user_behavior_agent_missing_data(self):

--- a/tests/unit/test_specialized_agents_errors.py
+++ b/tests/unit/test_specialized_agents_errors.py
@@ -9,19 +9,18 @@ Tests error paths and edge cases for specialized agent operations including:
 - Missing tools initialization
 """
 
-import asyncio
 from collections.abc import Generator
 from contextlib import ExitStack
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
-from agents.art import specialized_agents
 from helpers.specialized_agents_helpers import (
     patch_evaluation_agent_dependencies,
     patch_hypothesis_agent_dependencies,
     patch_ubi_agent_dependencies,
 )
+
+from agents.art import specialized_agents
 
 pytestmark = pytest.mark.unit
 
@@ -87,7 +86,7 @@ class TestSpecializedAgentsErrors:
         mock_agent = MagicMock()
         # Simulate timeout during agent invocation
         mock_agent.invoke_async = AsyncMock(
-            side_effect=asyncio.TimeoutError(
+            side_effect=TimeoutError(
                 "Agent execution timed out after 30 minutes"
             )
         )

--- a/tests/unit/test_ubi_metrics_tools.py
+++ b/tests/unit/test_ubi_metrics_tools.py
@@ -24,6 +24,7 @@ pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 async def _result(coro) -> dict:
     return json.loads(await coro)
 
@@ -41,17 +42,20 @@ def _click_buckets(
     """Build a click-by-query_id bucket list: [(query_id, query_text, doc_count), ...]."""
     buckets = []
     for qid, qt, count in pairs:
-        buckets.append({
-            "key": qid,
-            "doc_count": count,
-            agg_name: {"hits": {"hits": [{"_source": {field: qt}}]}},
-        })
+        buckets.append(
+            {
+                "key": qid,
+                "doc_count": count,
+                agg_name: {"hits": {"hits": [{"_source": {field: qt}}]}},
+            }
+        )
     return json.dumps(buckets)
 
 
 # ---------------------------------------------------------------------------
 # Global CTR
 # ---------------------------------------------------------------------------
+
 
 class TestGlobalCTR:
     async def test_basic_ctr(self):
@@ -82,26 +86,31 @@ class TestGlobalCTR:
 # Zero-click rate
 # ---------------------------------------------------------------------------
 
+
 class TestZeroClickRate:
     async def test_zero_click_rate_computed(self):
-        r = await _result(compute_ubi_metrics(
-            total_queries=100, total_clicks=30, queries_with_clicks=20
-        ))
+        r = await _result(
+            compute_ubi_metrics(
+                total_queries=100, total_clicks=30, queries_with_clicks=20
+            )
+        )
         assert r["zero_click_rate"] == 0.80
         assert r["zero_click_rate_pct"] == "80.00%"
         assert r["queries_with_clicks"] == 20
         assert r["queries_without_clicks"] == 80
 
     async def test_all_queries_have_clicks(self):
-        r = await _result(compute_ubi_metrics(
-            total_queries=50, total_clicks=50, queries_with_clicks=50
-        ))
+        r = await _result(
+            compute_ubi_metrics(
+                total_queries=50, total_clicks=50, queries_with_clicks=50
+            )
+        )
         assert r["zero_click_rate"] == 0.0
 
     async def test_no_queries_with_clicks(self):
-        r = await _result(compute_ubi_metrics(
-            total_queries=50, total_clicks=0, queries_with_clicks=0
-        ))
+        r = await _result(
+            compute_ubi_metrics(total_queries=50, total_clicks=0, queries_with_clicks=0)
+        )
         assert r["zero_click_rate"] == 1.0
 
     async def test_omitted_queries_with_clicks_skips_zero_click_rate(self):
@@ -113,14 +122,19 @@ class TestZeroClickRate:
 # Per-query CTR from raw buckets
 # ---------------------------------------------------------------------------
 
+
 class TestPerQueryCTR:
     async def test_basic_per_query_ctr(self):
         imp = _imp_buckets([("laptop", 100), ("phone", 50)])
         clk = _click_buckets([("qid-1", "laptop", 20), ("qid-2", "phone", 10)])
-        r = await _result(compute_ubi_metrics(
-            total_queries=150, total_clicks=30,
-            impression_buckets=imp, click_query_id_buckets=clk,
-        ))
+        r = await _result(
+            compute_ubi_metrics(
+                total_queries=150,
+                total_clicks=30,
+                impression_buckets=imp,
+                click_query_id_buckets=clk,
+            )
+        )
         by_query = {q["query"]: q for q in r["top_queries_by_ctr"]}
         assert by_query["laptop"]["ctr"] == 0.2
         assert by_query["laptop"]["ctr_pct"] == "20.00%"
@@ -130,10 +144,14 @@ class TestPerQueryCTR:
         imp = _imp_buckets([("laptop", 200)])
         # Two different query_ids both for "laptop"
         clk = _click_buckets([("qid-1", "laptop", 10), ("qid-2", "laptop", 15)])
-        r = await _result(compute_ubi_metrics(
-            total_queries=200, total_clicks=25,
-            impression_buckets=imp, click_query_id_buckets=clk,
-        ))
+        r = await _result(
+            compute_ubi_metrics(
+                total_queries=200,
+                total_clicks=25,
+                impression_buckets=imp,
+                click_query_id_buckets=clk,
+            )
+        )
         laptop = next(q for q in r["top_queries_by_ctr"] if q["query"] == "laptop")
         assert laptop["clicks"] == 25
         assert laptop["ctr"] == round(25 / 200, 4)
@@ -141,32 +159,48 @@ class TestPerQueryCTR:
     async def test_results_sorted_by_ctr_descending(self):
         imp = _imp_buckets([("a", 100), ("b", 100), ("c", 100)])
         clk = _click_buckets([("q1", "a", 50), ("q2", "b", 10), ("q3", "c", 30)])
-        r = await _result(compute_ubi_metrics(
-            total_queries=300, total_clicks=90,
-            impression_buckets=imp, click_query_id_buckets=clk,
-        ))
+        r = await _result(
+            compute_ubi_metrics(
+                total_queries=300,
+                total_clicks=90,
+                impression_buckets=imp,
+                click_query_id_buckets=clk,
+            )
+        )
         ctrs = [q["ctr"] for q in r["top_queries_by_ctr"]]
         assert ctrs == sorted(ctrs, reverse=True)
 
     async def test_query_with_impressions_but_no_clicks_has_zero_ctr(self):
         imp = _imp_buckets([("laptop", 100), ("tablet", 50)])
         clk = _click_buckets([("qid-1", "laptop", 10)])
-        r = await _result(compute_ubi_metrics(
-            total_queries=150, total_clicks=10,
-            impression_buckets=imp, click_query_id_buckets=clk,
-        ))
+        r = await _result(
+            compute_ubi_metrics(
+                total_queries=150,
+                total_clicks=10,
+                impression_buckets=imp,
+                click_query_id_buckets=clk,
+            )
+        )
         tablet = next(q for q in r["top_queries_by_ctr"] if q["query"] == "tablet")
         assert tablet["ctr"] == 0.0
         assert tablet["clicks"] == 0
 
-    async def test_query_with_clicks_but_no_impression_bucket_has_zero_impressions(self):
+    async def test_query_with_clicks_but_no_impression_bucket_has_zero_impressions(
+        self,
+    ):
         imp = _imp_buckets([("laptop", 100)])
         clk = _click_buckets([("qid-1", "laptop", 5), ("qid-2", "unknown_query", 3)])
-        r = await _result(compute_ubi_metrics(
-            total_queries=100, total_clicks=8,
-            impression_buckets=imp, click_query_id_buckets=clk,
-        ))
-        unknown = next((q for q in r["top_queries_by_ctr"] if q["query"] == "unknown_query"), None)
+        r = await _result(
+            compute_ubi_metrics(
+                total_queries=100,
+                total_clicks=8,
+                impression_buckets=imp,
+                click_query_id_buckets=clk,
+            )
+        )
+        unknown = next(
+            (q for q in r["top_queries_by_ctr"] if q["query"] == "unknown_query"), None
+        )
         assert unknown is not None
         assert unknown["impressions"] == 0
         assert unknown["ctr"] == 0.0
@@ -174,25 +208,39 @@ class TestPerQueryCTR:
     async def test_per_query_count_returned(self):
         imp = _imp_buckets([("a", 10), ("b", 20)])
         clk = _click_buckets([("q1", "a", 2)])
-        r = await _result(compute_ubi_metrics(
-            total_queries=30, total_clicks=2,
-            impression_buckets=imp, click_query_id_buckets=clk,
-        ))
+        r = await _result(
+            compute_ubi_metrics(
+                total_queries=30,
+                total_clicks=2,
+                impression_buckets=imp,
+                click_query_id_buckets=clk,
+            )
+        )
         assert r["per_query_count"] == 2
 
     async def test_custom_field_and_agg_name(self):
         imp = _imp_buckets([("laptop", 100)])
-        clk = json.dumps([{
-            "key": "qid-1",
-            "doc_count": 10,
-            "my_agg": {"hits": {"hits": [{"_source": {"search_text": "laptop"}}]}},
-        }])
-        r = await _result(compute_ubi_metrics(
-            total_queries=100, total_clicks=10,
-            impression_buckets=imp, click_query_id_buckets=clk,
-            query_text_field="search_text",
-            click_query_text_agg="my_agg",
-        ))
+        clk = json.dumps(
+            [
+                {
+                    "key": "qid-1",
+                    "doc_count": 10,
+                    "my_agg": {
+                        "hits": {"hits": [{"_source": {"search_text": "laptop"}}]}
+                    },
+                }
+            ]
+        )
+        r = await _result(
+            compute_ubi_metrics(
+                total_queries=100,
+                total_clicks=10,
+                impression_buckets=imp,
+                click_query_id_buckets=clk,
+                query_text_field="search_text",
+                click_query_text_agg="my_agg",
+            )
+        )
         laptop = next(q for q in r["top_queries_by_ctr"] if q["query"] == "laptop")
         assert laptop["ctr"] == 0.1
 
@@ -201,37 +249,51 @@ class TestPerQueryCTR:
 # Skipped / malformed buckets
 # ---------------------------------------------------------------------------
 
+
 class TestMalformedBuckets:
     async def test_bucket_missing_top_hits_agg_is_skipped(self):
         imp = _imp_buckets([("laptop", 100)])
         clk = json.dumps([{"key": "qid-1", "doc_count": 5}])  # no top_hits sub-agg
-        r = await _result(compute_ubi_metrics(
-            total_queries=100, total_clicks=5,
-            impression_buckets=imp, click_query_id_buckets=clk,
-        ))
+        r = await _result(
+            compute_ubi_metrics(
+                total_queries=100,
+                total_clicks=5,
+                impression_buckets=imp,
+                click_query_id_buckets=clk,
+            )
+        )
         assert r.get("skipped_click_buckets") == 1
         assert "skipped_reason" in r
 
     async def test_invalid_impression_buckets_json_returns_error(self):
-        r = await _result(compute_ubi_metrics(
-            total_queries=100, total_clicks=5,
-            impression_buckets="not-json",
-            click_query_id_buckets="[]",
-        ))
+        r = await _result(
+            compute_ubi_metrics(
+                total_queries=100,
+                total_clicks=5,
+                impression_buckets="not-json",
+                click_query_id_buckets="[]",
+            )
+        )
         assert "error" in r
 
     async def test_invalid_click_buckets_json_returns_error(self):
-        r = await _result(compute_ubi_metrics(
-            total_queries=100, total_clicks=5,
-            impression_buckets="[]",
-            click_query_id_buckets="{not-a-list}",
-        ))
+        r = await _result(
+            compute_ubi_metrics(
+                total_queries=100,
+                total_clicks=5,
+                impression_buckets="[]",
+                click_query_id_buckets="{not-a-list}",
+            )
+        )
         assert "error" in r
 
     async def test_non_list_impression_buckets_returns_error(self):
-        r = await _result(compute_ubi_metrics(
-            total_queries=100, total_clicks=5,
-            impression_buckets='{"key": "laptop"}',  # dict, not list
-            click_query_id_buckets="[]",
-        ))
+        r = await _result(
+            compute_ubi_metrics(
+                total_queries=100,
+                total_clicks=5,
+                impression_buckets='{"key": "laptop"}',  # dict, not list
+                click_query_id_buckets="[]",
+            )
+        )
         assert "error" in r


### PR DESCRIPTION
### Description
Fixes the linting for the codebase.

Applied import lint fixes and rule suppression for intentional import lint errors.

`UP047` rule in ruff recommends the new generic functions syntax from python >= 3.12 (`PEP 695`). I used `[T]` to update the functions to satisfy the new lint rule instead of using the top level `TypeVar` and same for `[R]`. 

Alternatively, we could suppress that rule if you prefer to keep the existing `TypeVar` way.

### Issues Resolved
Follow up to #15

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.