### PR TITLE
Chore: Add SPDX headers to .py files

### DIFF
--- a/run_server.py
+++ b/run_server.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """OpenSearch Agent Server — Entry Point.
 
 Run this server to expose the multi-agent orchestrator via AG-UI protocol.

--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+

--- a/src/agents/agentic_search/__init__.py
+++ b/src/agents/agentic_search/__init__.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Agentic-search agent: natural-language query -> OpenSearch DSL, via ``POST /invoke``."""
 
 from __future__ import annotations

--- a/src/agents/agentic_search/agent.py
+++ b/src/agents/agentic_search/agent.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """The ``agentic_search`` agent: NLQ -> OpenSearch DSL, reached via ``POST /invoke``.
 
 Given a natural-language ``query`` and a target ``index_name`` (in the structured

--- a/src/agents/agentic_search/prompts/__init__.py
+++ b/src/agents/agentic_search/prompts/__init__.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Prompts for the agentic-search agent, split by generation strategy.
 
 - :mod:`.direct_dsl` — rules, examples, ``EmitSearch`` schema, and cached system

--- a/src/agents/agentic_search/prompts/direct_dsl.py
+++ b/src/agents/agentic_search/prompts/direct_dsl.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Prompt, structured-output schema, and cached system blocks for direct-DSL generation.
 
 The system prompt is a large, static rules-and-examples prefix. It is sent as

--- a/src/agents/agentic_search/strategies/__init__.py
+++ b/src/agents/agentic_search/strategies/__init__.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Generation strategies, selected per request by ``context["strategy"]``.
 
 Each strategy turns a natural-language question into an OpenSearch ``_search``

--- a/src/agents/agentic_search/strategies/base.py
+++ b/src/agents/agentic_search/strategies/base.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """The generation-strategy contract for the agentic-search agent.
 
 A strategy turns a natural-language question into an OpenSearch ``_search`` body

--- a/src/agents/agentic_search/strategies/direct_dsl.py
+++ b/src/agents/agentic_search/strategies/direct_dsl.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Direct-DSL generation: the model authors the whole ``_search`` body.
 
 The default generation strategy. It gives the model the index mapping and one

--- a/src/agents/agentic_search/strategies/forced_tool.py
+++ b/src/agents/agentic_search/strategies/forced_tool.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Forced tool-call generation over Bedrock ``converse_stream``.
 
 Registers a Pydantic model as a tool and forces ``toolChoice`` so the model emits

--- a/src/agents/art/__init__.py
+++ b/src/agents/art/__init__.py
@@ -1,1 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 

--- a/src/agents/art/art_agent.py
+++ b/src/agents/art/art_agent.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """ART Agent — Search Relevance Testing Sub-Agent.
 
 Orchestrates 3 specialized agents for search relevance tuning:

--- a/src/agents/art/specialized_agents.py
+++ b/src/agents/art/specialized_agents.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """
 Specialized Agents for Search Relevance Tuning
 Following the "Agents as Tools" pattern with Strands SDK

--- a/src/agents/base.py
+++ b/src/agents/base.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Base types for sub-agents.
 
 Defines the protocol that sub-agent factories should follow.

--- a/src/agents/context_management.py
+++ b/src/agents/context_management.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Context management for the agents (issue #138).
 
 - ``SummarizingConversationManager`` (a Strands ``ConversationManager``) proactively

--- a/src/agents/default_agent.py
+++ b/src/agents/default_agent.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Default Agent — General OpenSearch Assistant.
 
 A simple Strands agent with all OpenSearch MCP Server tools.

--- a/src/agents/skill_loader.py
+++ b/src/agents/skill_loader.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Skill discovery — combines bundled and user-configured skill sources.
 
 Loads skills from two layers:

--- a/src/orchestrator/__init__.py
+++ b/src/orchestrator/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+

--- a/src/orchestrator/registry.py
+++ b/src/orchestrator/registry.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Agent Registry for the OpenSearch Agent Server.
 
 Maps page contexts to agent factories. The orchestrator uses this registry

--- a/src/orchestrator/router.py
+++ b/src/orchestrator/router.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Page-Context Router for the OpenSearch Agent Server.
 
 Routes incoming requests to the appropriate sub-agent based on page_context.

--- a/src/server/__init__.py
+++ b/src/server/__init__.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """AG-UI Server Package.
 
 Provides AG-UI protocol server for the multi-agent system.

--- a/src/server/ag_ui_app.py
+++ b/src/server/ag_ui_app.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """AG-UI Protocol FastAPI Server.
 
 Exposes the multi-agent system via AG-UI protocol for frontend integration.

--- a/src/server/ag_ui_event_processor.py
+++ b/src/server/ag_ui_event_processor.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Event Processor for AG-UI Protocol.
 
 Handles event generation, persistence, and activity monitoring for AG-UI events.

--- a/src/server/ag_ui_event_strategy.py
+++ b/src/server/ag_ui_event_strategy.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Strategy Pattern Event Handlers for AG-UI Event Processor.
 
 Implements the strategy pattern for handling different AG-UI event types in the

--- a/src/server/agent_orchestrator.py
+++ b/src/server/agent_orchestrator.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Agent Orchestrator — routes requests to AG-UI Strands agent wrappers.
 
 A fresh ``ag_ui_strands.StrandsAgent`` is created per request to isolate

--- a/src/server/auth_middleware.py
+++ b/src/server/auth_middleware.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Authentication middleware for AG-UI server.
 
 This module provides configurable authentication middleware that supports multiple

--- a/src/server/authorization.py
+++ b/src/server/authorization.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Standardized authorization helpers for AG-UI route handlers.
 
 This module provides consistent authorization patterns across all routes,

--- a/src/server/cli.py
+++ b/src/server/cli.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """CLI entry point for opensearch-agent-server.
 
 Provides the ``opensearch-agent-server`` console command installed by pip.

--- a/src/server/config.py
+++ b/src/server/config.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Centralized AG-UI server configuration using Pydantic settings.
 
 This module provides centralized configuration management using Pydantic settings

--- a/src/server/constants.py
+++ b/src/server/constants.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Constants for AG-UI server configuration.
 
 This module contains all magic numbers and hardcoded values used throughout

--- a/src/server/error_classification.py
+++ b/src/server/error_classification.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Error classification utilities for determining error types and recovery strategies.
 
 This module provides utilities for classifying errors into categories

--- a/src/server/error_recovery.py
+++ b/src/server/error_recovery.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Error recovery strategies for transient failures and partial success handling.
 
 This module provides utilities for handling transient errors, implementing

--- a/src/server/exceptions.py
+++ b/src/server/exceptions.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Standardized exception classes for AG-UI server error handling.
 
 This module provides a consistent exception hierarchy for API errors,

--- a/src/server/logging_config.py
+++ b/src/server/logging_config.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Logging configuration utilities for AG-UI server.
 
 Provides JSON formatter for structured logging, request ID injection, and

--- a/src/server/rate_limiting.py
+++ b/src/server/rate_limiting.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Rate limiting middleware for AG-UI FastAPI server.
 
 This module provides rate limiting functionality to protect the API from

--- a/src/server/request_id_middleware.py
+++ b/src/server/request_id_middleware.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Request ID middleware for AG-UI server.
 
 Assigns a unique request_id to each HTTP request, stores it in request.state and

--- a/src/server/response_formats.py
+++ b/src/server/response_formats.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Optional ``/invoke`` response envelopes, selected by the ``response_format`` field.
 
 These shape *any* agent's string reply for a specific consumer; they are not tied

--- a/src/server/retry.py
+++ b/src/server/retry.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Retry logic with exponential backoff for transient failures.
 
 This module provides retry utilities with configurable backoff strategies

--- a/src/server/route_helpers.py
+++ b/src/server/route_helpers.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Helper functions for AG-UI route handlers.
 
 This module provides utility functions used across route handlers,

--- a/src/server/run_manager.py
+++ b/src/server/run_manager.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Run Manager for tracking and canceling active AG-UI runs (run_id -> asyncio.Task).
 
 Manages active runs by tracking run_id -> asyncio.Task mappings,

--- a/src/server/run_route_helpers.py
+++ b/src/server/run_route_helpers.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Helper functions for create_run_route to reduce complexity.
 
 This module extracts cancellation handling and event stream management logic

--- a/src/server/run_routes.py
+++ b/src/server/run_routes.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Route handlers for run-related AG-UI endpoints.
 
 This module contains route handlers for creating runs, getting run details,

--- a/src/server/types.py
+++ b/src/server/types.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Type definitions for AG-UI server.
 
 This module provides Protocol classes and type aliases for better type safety

--- a/src/server/utils.py
+++ b/src/server/utils.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Utility functions for AG-UI server.
 
 This module contains helper functions to reduce code duplication and improve

--- a/src/server/validators.py
+++ b/src/server/validators.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Centralized input validation using Pydantic validators.
 
 This module provides validated models for request inputs with comprehensive

--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+

--- a/src/tools/art/__init__.py
+++ b/src/tools/art/__init__.py
@@ -1,1 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 

--- a/src/tools/art/experiment_tools.py
+++ b/src/tools/art/experiment_tools.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """
 Experiment Tools
 Tools for aggregating search relevance experiment results.

--- a/src/tools/art/ubi_metrics_tools.py
+++ b/src/tools/art/ubi_metrics_tools.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """
 UBI Metrics Tools
 

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+

--- a/src/utils/activity_monitor.py
+++ b/src/utils/activity_monitor.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """
 AG-UI Activity Monitor
 

--- a/src/utils/logging_helpers.py
+++ b/src/utils/logging_helpers.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Logging helper functions for standardized logging patterns.
 
 Provides helper functions for consistent logging across the codebase with:

--- a/src/utils/model_factory.py
+++ b/src/utils/model_factory.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """LLM model factory — creates the right model based on environment config.
 
 Auto-detects the provider from environment variables:

--- a/src/utils/monitored_tool.py
+++ b/src/utils/monitored_tool.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """
 Monitored Tool Decorator
 

--- a/src/utils/obo_context.py
+++ b/src/utils/obo_context.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Per-request OBO token injection for httpx clients.
 
 Provides concurrency-safe token propagation that works across async contexts

--- a/src/utils/persistence.py
+++ b/src/utils/persistence.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """
 AG-UI Data Persistence Service
 

--- a/src/utils/tool_utils.py
+++ b/src/utils/tool_utils.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Utility functions for tool error formatting.
 
 This module provides standardized error response formatting for all tool functions

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """
 Pytest configuration and shared fixtures for opensearch-agent-server tests.
 """

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """
 Test helpers for specialized agents testing.
 

--- a/tests/helpers/specialized_agents_helpers.py
+++ b/tests/helpers/specialized_agents_helpers.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """
 Helper functions for patching dependencies in specialized agent tests.
 

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+

--- a/tests/integration/test_specialized_agents.py
+++ b/tests/integration/test_specialized_agents.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """
 Integration tests for Specialized Agents.
 

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+

--- a/tests/unit/test_agentic_search_agent.py
+++ b/tests/unit/test_agentic_search_agent.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Unit tests for the agentic_search agent (reached via POST /invoke).
 
 The OpenSearch client and the generation strategy are stubbed, so nothing hits a

--- a/tests/unit/test_context_management.py
+++ b/tests/unit/test_context_management.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Unit tests for context management primitives (issue #138).
 
 Context management is built on two Strands vended primitives:

--- a/tests/unit/test_default_agent.py
+++ b/tests/unit/test_default_agent.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Unit tests for the default agent — skill loading and agent construction.
 
 Verifies that:

--- a/tests/unit/test_direct_dsl_strategy.py
+++ b/tests/unit/test_direct_dsl_strategy.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Unit tests for the direct_dsl strategy's provider routing.
 
 The forced-tool path is Bedrock-specific (drives ``converse_stream`` directly),

--- a/tests/unit/test_experiment_tools.py
+++ b/tests/unit/test_experiment_tools.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """
 Unit tests for experiment tools.
 

--- a/tests/unit/test_experiment_tools_errors.py
+++ b/tests/unit/test_experiment_tools_errors.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """
 Unit tests for experiment tools error scenarios.
 

--- a/tests/unit/test_invoke_endpoint.py
+++ b/tests/unit/test_invoke_endpoint.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Unit tests for the /invoke non-streaming endpoint."""
 
 from __future__ import annotations

--- a/tests/unit/test_model_factory.py
+++ b/tests/unit/test_model_factory.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Unit tests for the LLM model factory."""
 
 from __future__ import annotations

--- a/tests/unit/test_monitored_tool.py
+++ b/tests/unit/test_monitored_tool.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """
 Unit tests for monitored_tool decorator.
 

--- a/tests/unit/test_orchestrator_concurrency.py
+++ b/tests/unit/test_orchestrator_concurrency.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Unit tests for AgentOrchestrator credential isolation and resource cleanup.
 
 Tests verify that the per-request agent creation fix:

--- a/tests/unit/test_response_formats.py
+++ b/tests/unit/test_response_formats.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Unit tests for the /invoke response envelopes."""
 
 from __future__ import annotations

--- a/tests/unit/test_skill_loader.py
+++ b/tests/unit/test_skill_loader.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Unit tests for agents.skill_loader."""
 
 from __future__ import annotations

--- a/tests/unit/test_specialized_agents_errors.py
+++ b/tests/unit/test_specialized_agents_errors.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """
 Unit tests for specialized agents error scenarios.
 

--- a/tests/unit/test_tool_utils.py
+++ b/tests/unit/test_tool_utils.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """
 Unit tests for tool_utils module.
 

--- a/tests/unit/test_ubi_metrics_tools.py
+++ b/tests/unit/test_ubi_metrics_tools.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """
 Unit tests for compute_ubi_metrics.
 

--- a/tests/unit/test_validators.py
+++ b/tests/unit/test_validators.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
 """Unit tests for request input validation — tool-result size bound (issue #138).
 
 Verifies that ``ValidatedRunAgentInput`` caps client-returned tool results at the API


### PR DESCRIPTION
### Description
Adds Apache 2.0 SPDX license headers to all .py files under:

- `src/server/`
- `src/orchestrator/`
- `src/agents/`
-  `src/utils/`
- `tests/`
- `run_server.py.`

### Issues Resolved
Closes #5 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
