### PR TITLE
Drop the free-DSL rationale field from EmitSearch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - `/invoke` `context` (structured input forwarded to the agent) and `response_format` (opt-in ml-commons `inference_results` envelope) request fields
 - `template_fill` generation strategy for `agentic_search`: fills a registered search template's Mustache parameters and renders them via `_render/template`, selected by passing `context.template_id`
 
+### Changed
+- Drop the `reason` field from the `agentic_search` free-DSL output. It was decoded on every request and only logged, never used to build the query; removing it cuts free-DSL generation latency substantially with no accuracy change
+
 ### Fixed
 - Bundled skills (`ppl-reference`) are now included in the pip wheel — previously only available from git clones
 - Default agent now respects `BEDROCK_INFERENCE_PROFILE_ARN` env var instead of silently falling back to a hardcoded Sonnet 4 model (fixes #94)

--- a/src/agents/agentic_search/prompts/direct_dsl.py
+++ b/src/agents/agentic_search/prompts/direct_dsl.py
@@ -25,7 +25,7 @@ FALLBACK_DSL = '{"size":10,"query":{"match_all":{}}}'
 
 
 class EmitSearch(BaseModel):
-    """Structured output the model returns: the DSL plus a one-line rationale.
+    """Structured output the model returns: the ``_search`` body.
 
     ``dsl`` is an open object (no rigid sub-schema) so the model can emit any
     valid OpenSearch query body.
@@ -33,9 +33,6 @@ class EmitSearch(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    reason: str = Field(
-        description="One short line mapping each clause of the DSL to the user's words."
-    )
     dsl: dict[str, Any] = Field(
         description="The OpenSearch _search request body as a JSON object."
     )
@@ -166,7 +163,6 @@ OUTPUT_FORMAT_INSTRUCTIONS = (
     "==== OUTPUT FORMAT ====\n"
     "- Put the OpenSearch request body (a single JSON object) in the `dsl` field of the EmitSearch tool call.\n"
     "- Use valid JSON only: standard double quotes for all keys/strings; no comments; no trailing commas.\n"
-    "- In the `reason` field, briefly map each clause to the user's words.\n"
     "- If the request truly cannot be fulfilled because no remotely relevant fields exist, set `dsl` to EXACTLY:\n"
     + FALLBACK_DSL
     + "\n"

--- a/src/agents/agentic_search/strategies/direct_dsl.py
+++ b/src/agents/agentic_search/strategies/direct_dsl.py
@@ -9,9 +9,9 @@
 The default generation strategy. It gives the model the index mapping and one
 sample document, then has it author a complete OpenSearch query body:
 
-- On Bedrock, a single forced tool call (see :func:`forced_tool_fill`) keeps the
-  model's ``EmitSearch`` rationale inside the tool input rather than as leading
-  free text. Other providers (e.g. Ollama) use the portable strands
+- On Bedrock, a single forced tool call (see :func:`forced_tool_fill`) makes the
+  model emit the ``EmitSearch`` tool input immediately, with no leading free
+  text. Other providers (e.g. Ollama) use the portable strands
   ``structured_output`` path, which does not support forcing ``toolChoice``.
 - The sample document supplies real field values (e.g. exact keyword/enum values),
   which the mapping alone does not, helping the model choose the right field and term.
@@ -92,9 +92,7 @@ class DirectDslStrategy:
             sample_document=sample or "(none available)",
         )
         result = self._emit(request.model, user_msg)
-        logger.info(
-            "Generated DSL for index=%s (reason=%s)", request.index_name, result.reason
-        )
+        logger.info("Generated DSL for index=%s", request.index_name)
         return result.dsl
 
     @staticmethod


### PR DESCRIPTION
### Description

Drops the `reason` field from the `agentic_search` free-DSL output (`EmitSearch`).

The tool asked the model to emit a one-line rationale mapping each DSL clause to the user's words. Nothing downstream read it — it was decoded on every free-DSL request and only written to one log line, never used to build the query. Removing it lowers free-DSL generation latency with no accuracy change, since the rationale never influenced the emitted DSL.

### Measured impact

Benchmarked on the stress-bench-v2 NLQ→DSL set (`catalog-northpeak`, 32 questions), free-DSL path, isolating the `reason` field as the only variable:

Every one of the 32 questions was faster without the field (mean −2727 ms, ~58%); the smallest single-question improvement was 885 ms. Accuracy is unchanged.

### Changes
- Remove `reason` from `EmitSearch` and the corresponding OUTPUT FORMAT instruction line.
- Drop `reason` from the generation log line.
- CHANGELOG entry under Unreleased → Changed.

### Check List
- [x] Existing unit tests pass (`tests/unit/test_direct_dsl_strategy.py`, `test_agentic_search_agent.py`, and the agentic-search suite: 43 passed)
- [x] `ruff check` clean
- [x] Verified end-to-end against a live cluster (free-DSL still emits valid DSL)
- [x] Commits are signed (DCO)
